### PR TITLE
Support PowerDNS 4 API

### DIFF
--- a/PestJSON.php
+++ b/PestJSON.php
@@ -195,6 +195,7 @@ class PestJSON extends Pest
      */
     public function processBody($body)
     {
+        if($body == '') return false;
         return $this->jsonDecode($body);
     }
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ Features
 Compatibility
 -------------
 
-The current version is only compatible with the experimental JSON API of PowerDNS 3.
-
-A branch exists that implements full PowerDNS 4 support, but PowerDNS 4 has [a serious API
-bug](https://github.com/PowerDNS/pdns/issues/4766) that greatly affects functionality of the DNS UI and can lead to data
-corruption.
+The current version is only compatible with PowerDNS 4.1.0 and higher.
 
 Requirements
 ------------
@@ -34,7 +30,7 @@ Requirements
 * PHP LDAP extension
 * PHP PDO_PGSQL extension
 * PostgreSQL database
-* PowerDNS authoritative server (>= 3.4.2, < 4.0)
+* PowerDNS authoritative server (>= 4.1.0)
 
 Installation
 ------------

--- a/core.php
+++ b/core.php
@@ -184,6 +184,12 @@ function simplify_search($defaults, $values) {
 	}
 }
 
+class DNSZoneName {
+	public static function unqualify($name) {
+		return rtrim($name, '.');
+	}
+}
+
 class DNSName {
 	public static function abbreviate($name, $zonename) {
 		if(strrpos($name, $zonename) === strlen($name) - strlen($zonename)) {
@@ -191,12 +197,12 @@ class DNSName {
 			if($name == '') return '@';
 			else return $name;
 		} else {
-			return "$name.";
+			return $name;
 		}
 	}
 	public static function canonify($name, $zonename) {
 		if($name == '@') return $zonename;
-		if(substr($name, -1) == '.') return substr($name, 0, -1);
+		if(substr($name, -1) == '.') return $name;
 		return "$name.$zonename";
 	}
 }
@@ -204,7 +210,7 @@ class DNSName {
 class DNSTime {
 	public static function abbreviate($time) {
 		// Although formats like "3w12h" are allowed, we're discouraging that use by only returning 1 unit
-		if($time % 60 != 0) return $time;
+		if($time % 60 != 0 || $time == 0) return $time;
 		if($time % (60 * 60) != 0) return ($time / 60).'M';
 		if($time % (60 * 60 * 24) != 0) return ($time / 60 / 60).'H';
 		if($time % (60 * 60 * 24 * 7) != 0) return $time / (60 * 60 * 24).'D';
@@ -340,29 +346,29 @@ function ipv6_address_expand($address) {
 }
 
 function ipv4_reverse_zone_to_range($zonename) {
-	// eg. 3.2.1.in-addr.arpa
-	$result = substr($zonename, 0, -13); // Chop off .in-addr.arpa = 3.2.1
-	$result = explode('.', $result);     // Split by .             = 3, 2, 1
-	$result = array_reverse($result);    // Reverse chunks         = 1, 2, 3
-	$result = implode('.', $result).'.'; // Combine with .         = 1.2.3.
+	// eg. 3.2.1.in-addr.arpa.
+	$result = substr($zonename, 0, -14); // Chop off .in-addr.arpa. = 3.2.1
+	$result = explode('.', $result);     // Split by .              = 3, 2, 1
+	$result = array_reverse($result);    // Reverse chunks          = 1, 2, 3
+	$result = implode('.', $result).'.'; // Combine with .          = 1.2.3.
 	return $result;
 }
 
 function ipv4_reverse_zone_to_subnet($zonename) {
-	// eg. 3.2.1.in-addr.arpa
-	$result = substr($zonename, 0, -13);   // Chop off .in-addr.arpa = 3.2.1
-	$result = explode('.', $result);       // Split by .             = 3, 2, 1
-	$result = array_reverse($result);      // Reverse chunks         = 1, 2, 3
+	// eg. 3.2.1.in-addr.arpa.
+	$result = substr($zonename, 0, -14);   // Chop off .in-addr.arpa. = 3.2.1
+	$result = explode('.', $result);       // Split by .              = 3, 2, 1
+	$result = array_reverse($result);      // Reverse chunks          = 1, 2, 3
 	$prefix_len = count($result) * 8;
-	$result = array_pad($result, 4, '0');  // Pad with zero chunks   = 1, 2, 3, 0
-	$result = implode('.', $result);       // Combine with .         = 1.2.3.0
-	$result .= '/'.$prefix_len;            // Append prefix length   = 1.2.3.0/24
+	$result = array_pad($result, 4, '0');  // Pad with zero chunks    = 1, 2, 3, 0
+	$result = implode('.', $result);       // Combine with .          = 1.2.3.0
+	$result .= '/'.$prefix_len;            // Append prefix length    = 1.2.3.0/24
 	return $result;
 }
 
 function ipv6_reverse_zone_to_range($zonename) {
-	// eg. 2.2.8.b.d.0.1.0.0.2.ip6.arpa
-	$result = substr($zonename, 0, -9);       // Chop off .ip6.arpa         = 2.2.8.b.d.0.1.0.0.2
+	// eg. 2.2.8.b.d.0.1.0.0.2.ip6.arpa.
+	$result = substr($zonename, 0, -10);      // Chop off .ip6.arpa.        = 2.2.8.b.d.0.1.0.0.2
 	$result = explode('.', $result);          // Split by . separators      = 2, 2, 8, b, d, 0, 1, 0, 0, 2
 	$result = array_reverse($result);         // Reverse chunks             = 2, 0, 0, 1, 0, d, b, 8, 2, 2
 	$result = implode('', $result);           // Combine into single string = 20010db822
@@ -374,8 +380,8 @@ function ipv6_reverse_zone_to_range($zonename) {
 }
 
 function ipv6_reverse_zone_to_subnet($zonename) {
-	// eg. 2.2.8.b.d.0.1.0.0.2.ip6.arpa
-	$result = substr($zonename, 0, -9);       // Chop off .ip6.arpa         = 2.2.8.b.d.0.1.0.0.2
+	// eg. 2.2.8.b.d.0.1.0.0.2.ip6.arpa.
+	$result = substr($zonename, 0, -10);      // Chop off .ip6.arpa.        = 2.2.8.b.d.0.1.0.0.2
 	$result = explode('.', $result);          // Split by . separators      = 2, 2, 8, b, d, 0, 1, 0, 0, 2
 	$result = array_reverse($result);         // Reverse chunks             = 2, 0, 0, 1, 0, d, b, 8, 2, 2
 	$result = implode('', $result);           // Combine into single string = 20010db822

--- a/routes.php
+++ b/routes.php
@@ -17,11 +17,11 @@
 
 $routes = array(
 	'/' => 'home',
-	'/api/v1' => 'api',
-	'/api/v1/{objects}' => 'api',
-	'/api/v1/{objects}/{id}' => 'api',
-	'/api/v1/{objects}/{id}/{subobjects}' => 'api',
-	'/api/v1/{objects}/{id}/{subobjects}/{subid}' => 'api',
+	'/api/v2' => 'api',
+	'/api/v2/{objects}' => 'api',
+	'/api/v2/{objects}/{id}' => 'api',
+	'/api/v2/{objects}/{id}/{subobjects}' => 'api',
+	'/api/v2/{objects}/{id}/{subobjects}/{subid}' => 'api',
 	'/templates' => 'templates',
 	'/templates/{type}' => 'templates',
 	'/templates/{type}/{name}' => 'template',

--- a/templates/apihelp.php
+++ b/templates/apihelp.php
@@ -21,19 +21,19 @@
 	<li>
 		<a href="#zones">Zones</a>
 		<ul>
-			<li><a href="#zones-get">GET /api/v1/zones</a></li>
-			<li><a href="#zones-name-get">GET /api/v1/zones/{name}</a></li>
-			<li><a href="#zones-name-patch">PATCH /api/v1/zones/{name}</a></li>
-			<li><a href="#zones-name-changes-get">GET /api/v1/zones/{name}/changes</a></li>
-			<li><a href="#zones-name-changes-id-get">GET /api/v1/zones/{name}/changes/{id}</a></li>
+			<li><a href="#zones-get">GET /api/v2/zones</a></li>
+			<li><a href="#zones-name-get">GET /api/v2/zones/{name}</a></li>
+			<li><a href="#zones-name-patch">PATCH /api/v2/zones/{name}</a></li>
+			<li><a href="#zones-name-changes-get">GET /api/v2/zones/{name}/changes</a></li>
+			<li><a href="#zones-name-changes-id-get">GET /api/v2/zones/{name}/changes/{id}</a></li>
 		</ul>
 	</li>
 </ul>
 <h2 id="zones">Zones</h2>
-<h3 id="zones-get">GET /api/v1/zones</h3>
+<h3 id="zones-get">GET /api/v2/zones</h3>
 <p>Returns an array of all zones.</p>
 <h4>Example</h4>
-<pre>GET /api/v1/zones</pre>
+<pre>GET /api/v2/zones</pre>
 <h5>Response content</h5>
 <?php syntax_highlight('[
     {
@@ -54,16 +54,16 @@
     }
 ]', 'javascript')?>
 <!--
-<h3>POST /api/v1/zones</h3>
+<h3>POST /api/v2/zones</h3>
 <p>Creates a new zone.</p>
 <h4>Example</h4>
 <pre><code>[
 ]</code></pre>
 -->
-<h3 id="zones-name-get">GET /api/v1/zones/{name}</h3>
+<h3 id="zones-name-get">GET /api/v2/zones/{name}</h3>
 <p>Returns all data regarding the named zone.</p>
 <h4>Example</h4>
-<pre>GET /api/v1/zones/example.com</pre>
+<pre>GET /api/v2/zones/example.com</pre>
 <h5>Response content</h5>
 <?php syntax_highlight('{
     "name": "example.com",
@@ -72,9 +72,9 @@
         {
             "name": "@",
             "type": "SOA",
+            "ttl": "1H",
             "records": [
                 {
-                    "ttl": "1H",
                     "content": "ns.example.net hostmaster.example.com 2016020200 28800 7200 604800 86400",
                     "enabled": true
                 }
@@ -84,14 +84,13 @@
         {
             "name": "@",
             "type": "NS",
+            "ttl": "1H",
             "records": [
                 {
-                    "ttl": "1H",
                     "content": "ns1.example.net",
                     "enabled": true
                 },
                 {
-                    "ttl": "1H",
                     "content": "ns2.example.net",
                     "enabled": true
                 }
@@ -101,9 +100,9 @@
         {
             "name": "record-1",
             "type": "A",
+            "ttl": "1H",
             "records": [
                 {
-                    "ttl": "1H",
                     "content": "1.1.1.1",
                     "enabled": true
                 }
@@ -119,9 +118,9 @@
         {
             "name": "record3",
             "type": "AAAA",
+            "ttl": "1H",
             "records": [
                 {
-                    "ttl": "1H",
                     "content": "2001:db8:3000:620:107:167:104:10",
                     "enabled": true
                 }
@@ -136,7 +135,7 @@
         }
     ]
 }', 'javascript')?>
-<h3 id="zones-name-patch">PATCH /api/v1/zones/{name}</h3>
+<h3 id="zones-name-patch">PATCH /api/v2/zones/{name}</h3>
 <p>Update recordsets in the named zone. Multiple actions can be performed in a single request, of which there are 3 types:</p>
 <ul>
 	<li><code>add</code> - create a new resource recordset</li>
@@ -144,7 +143,7 @@
 	<li><code>delete</code> - remove an existing resource recordset</li>
 </ul>
 <h4>Example</h4>
-<pre>PATCH /api/v1/zones/example.com</pre>
+<pre>PATCH /api/v2/zones/example.com</pre>
 <h5>Request content</h5>
 <?php syntax_highlight('{
 	"actions": [
@@ -152,10 +151,10 @@
 			"action": "add",
 			"name": "record2",
 			"type": "A",
+			"ttl": "1D",
 			"comment": "Issue 1234",
 			"records": [
 				{
-					"ttl": "1D",
 					"content": "10.10.10.10",
 					"enabled": true
 				}
@@ -167,15 +166,14 @@
 			"oldtype": "A",
 			"name": "record1",
 			"type": "A",
+			"ttl": "1H",
 			"comment": "Issue 1232",
 			"records": [
 				{
-					"ttl": "1H",
 					"content": "1.1.1.1",
 					"enabled": true
 				},
 				{
-					"ttl": "1H",
 					"content": "1.1.1.2",
 					"enabled": true
 				}
@@ -189,10 +187,10 @@
 	],
 	"comment": "A comment for this update"
 }', 'javascript')?>
-<h3 id="zones-name-changes-get">GET /api/v1/zones/{name}/changes</h3>
+<h3 id="zones-name-changes-get">GET /api/v2/zones/{name}/changes</h3>
 <p>Returns all changelog entries for the named zone.</p>
 <h4>Example</h4>
-<pre>GET /api/v1/zones/example.com/changes</pre>
+<pre>GET /api/v2/zones/example.com/changes</pre>
 <h5>Response content</h5>
 <?php syntax_highlight('[
     {
@@ -212,10 +210,10 @@
         "added": 1
     }
 ]', 'javascript')?>
-<h3 id="zones-name-changes-id-get">GET /api/v1/zones/{name}/changes/{id}</h3>
+<h3 id="zones-name-changes-id-get">GET /api/v2/zones/{name}/changes/{id}</h3>
 <p>Returns full change information for a specific changeset within the named zone.</p>
 <h4>Example</h4>
-<pre>GET /api/v1/zones/example.com/changes/207</pre>
+<pre>GET /api/v2/zones/example.com/changes/207</pre>
 <h5>Response content</h5>
 <?php syntax_highlight('{
     "id": 207,
@@ -229,9 +227,9 @@
             "before": {
                 "name": "record3.example.com",
                 "type": "A",
+                "ttl": "1H",
                 "rrs": [
                     {
-                        "ttl": "1H",
                         "content": "1.1.1.1",
                         "enabled": true
                     }
@@ -241,9 +239,9 @@
             "after": {
                 "name": "record3.example.com",
                 "type": "A",
+                "ttl": "1H",
                 "rrs": [
                     {
-                        "ttl": "1H",
                         "content": "1.1.1.1",
                         "enabled": false
                     }

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -31,10 +31,10 @@ $reverse = false;
 global $output_formatter;
 ?>
 <h1>
-	<?php out(idn_to_utf8($zone->name, 0, INTL_IDNA_VARIANT_UTS46))?> zone
-	<?php if(substr($zone->name, -13) == '.in-addr.arpa') { $reverse = true; ?>
-	<small>IPv4 reverse zone for <?php out(implode('.', array_reverse(explode('.', substr($zone->name, 0, -13)))).'.')?></small>
-	<?php } elseif(substr($zone->name, -9) == '.ip6.arpa') { $reverse = true; ?>
+	<?php out(DNSZoneName::unqualify(idn_to_utf8($zone->name, 0, INTL_IDNA_VARIANT_UTS46)))?> zone
+	<?php if(substr($zone->name, -14) == '.in-addr.arpa.') { $reverse = true; ?>
+	<small>IPv4 reverse zone for <?php out(ipv4_reverse_zone_to_range($zone->name))?></small>
+	<?php } elseif(substr($zone->name, -10) == '.ip6.arpa.') { $reverse = true; ?>
 	<small>IPv6 reverse zone for <tt><?php out(ipv6_reverse_zone_to_range($zone->name))?></tt></small>
 	<?php } ?>
 </h1>
@@ -52,7 +52,7 @@ global $output_formatter;
 <div class="tab-content">
 	<div role="tabpanel" class="tab-pane active" id="records">
 		<h2 class="sr-only">Resource records</h2>
-		<form method="post" action="/zones/<?php out($zone->name, ESC_URL)?>" class="zoneedit" data-local-zone="<?php out($local_zone ? 1 : 0)?>" data-local-ipv4-ranges="<?php out($local_ipv4_ranges)?>" data-local-ipv6-ranges="<?php out($local_ipv6_ranges)?>">
+		<form method="post" action="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>" class="zoneedit" data-local-zone="<?php out($local_zone ? 1 : 0)?>" data-local-ipv4-ranges="<?php out($local_ipv4_ranges)?>" data-local-ipv6-ranges="<?php out($local_ipv6_ranges)?>">
 			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 			<nav></nav>
 			<table class="table table-bordered table-condensed table-hover stickyHeader rrsets">
@@ -84,6 +84,7 @@ global $output_formatter;
 					<tr data-name="<?php out(idn_to_utf8($name, 0, INTL_IDNA_VARIANT_UTS46))?>" data-type="<?php out($rrset->type)?>" data-rrsetnum="<?php out($rrsetnum)?>" class="<?php out(implode(' ', $rowclasses))?>">
 						<td class="name" rowspan="<?php out(count($rrs))?>"><?php out(idn_to_utf8($name, 0, INTL_IDNA_VARIANT_UTS46))?></td>
 						<td class="type" rowspan="<?php out(count($rrs))?>"><?php out($rrset->type)?></td>
+						<td class="ttl" rowspan="<?php out(count($rrs))?>"><?php out(DNSTime::abbreviate($rrset->ttl))?></td>
 						<?php
 						$count = 0;
 						foreach($rrs as $rr) {
@@ -100,7 +101,6 @@ global $output_formatter;
 							}
 							$rr->content = DNSContent::decode($rr->content, $rrset->type);
 							?>
-						<td class="ttl"><?php out(DNSTime::abbreviate($rr->ttl))?></td>
 						<td class="content"><?php out($rr->content)?></td>
 						<td class="enabled"><?php out($rr->disabled ? 'No' : 'Yes')?></td>
 						<td class="actions">
@@ -161,7 +161,7 @@ global $output_formatter;
 			<nav></nav>
 			<input type="hidden" id="maxperpage" value="<?php out($maxperpage)?>">
 		</form>
-		<form method="post" action="/zones/<?php out($zone->name, ESC_URL)?>">
+		<form method="post" action="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>">
 			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 			<div id="updates" style="display:none">
 				<h3>Updates</h3>
@@ -204,7 +204,7 @@ global $output_formatter;
 			}
 		}
 		?>
-		<form method="post" action="/zones/<?php out($zone->name, ESC_URL)?>" class="pending_update">
+		<form method="post" action="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>" class="pending_update">
 			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 			<div class="panel panel-default">
 				<div class="panel-heading">
@@ -314,7 +314,7 @@ global $output_formatter;
 	</div>
 	<div role="tabpanel" class="tab-pane" id="soa">
 		<h2 class="sr-only">Zone configuration</h2>
-		<form method="post" action="/zones/<?php out($zone->name, ESC_URL)?>" class="form-horizontal zoneeditsoa">
+		<form method="post" action="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>" class="form-horizontal zoneeditsoa">
 			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 			<h3>Zone classification</h3>
 			<div class="form-group">
@@ -432,9 +432,9 @@ global $output_formatter;
 	<div role="tabpanel" class="tab-pane" id="import">
 		<h2 class="sr-only">Export / Import</h2>
 		<h3>Export zone</h3>
-		<a href="/zones/<?php out($zone->name, ESC_URL)?>/export" class="btn btn-primary">Export zone in bind9 format</a>
+		<a href="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>/export" class="btn btn-primary">Export zone in bind9 format</a>
 		<h3>Import zone</h3>
-		<form method="post" action="/zones/<?php out($zone->name, ESC_URL)?>/import" enctype="multipart/form-data">
+		<form method="post" action="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>/import" enctype="multipart/form-data">
 			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 			<div class="form-group">
 				<label>bind9 zone file</label>
@@ -462,13 +462,13 @@ global $output_formatter;
 		<h2 class="sr-only">Tools</h2>
 		<h3>Split zone</h3>
 		<p>This tool allows you to split records off into a separate new zone.</p>
-		<form method="post" action="/zones/<?php out($zone->name, ESC_URL)?>/split" class="form-inline">
+		<form method="post" action="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>/split" class="form-inline">
 			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 			<label for="zone_split_prefix" class="sr-only">Suffix</label>
 			<div class="input-group">
 				<div class="input-group-addon">*.</div>
 				<input type="text" id="zone_split_suffix" name="suffix" class="form-control" required>
-				<div class="input-group-addon">.<?php out(idn_to_utf8($zone->name, 0, INTL_IDNA_VARIANT_UTS46))?></div>
+				<div class="input-group-addon">.<?php out(idn_to_utf8(DNSZoneName::unqualify($zone->name), 0, INTL_IDNA_VARIANT_UTS46))?></div>
 			</div>
 			<button type="submit" class="btn btn-primary">Split matching records into new zone…</button>
 		</form>
@@ -509,7 +509,7 @@ global $output_formatter;
 		<?php if(count($access) == 0) { ?>
 		<p>No users have been assigned to this zone.</p>
 		<?php } else { ?>
-		<form method="post" action="/zones/<?php out($zone->name, ESC_URL)?>">
+		<form method="post" action="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>">
 			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 			<table class="table table-condensed table-bordered">
 				<thead>
@@ -536,7 +536,7 @@ global $output_formatter;
 		</form>
 		<?php } ?>
 		<?php if($active_user->admin) { ?>
-		<form method="post" action="/zones/<?php out($zone->name, ESC_URL)?>" class="form-horizontal">
+		<form method="post" action="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>" class="form-horizontal">
 			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 			<div class="form-group">
 				<label for="uid" class="col-sm-2 control-label">Username</label>

--- a/templates/zoneimport.php
+++ b/templates/zoneimport.php
@@ -20,11 +20,11 @@ $checked = 'checked ';
 $count = 0;
 $limit = 2500;
 ?>
-<h1>Import preview for <?php out($zone->name)?> zone update</h1>
+<h1>Import preview for <?php out(DNSZoneName::unqualify(idn_to_utf8($zone->name, 0, INTL_IDNA_VARIANT_UTS46)))?> zone update</h1>
 <?php if(count($modifications['add']) == 0 && count($modifications['update']) == 0 && count($modifications['delete']) == 0) { ?>
-<p>No changes have been made! <a href="/zones/<?php out($zone->name, ESC_URL)?>">Go back</a>.</p>
+<p>No changes have been made! <a href="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>">Go back</a>.</p>
 <?php } else { ?>
-<form method="post" action="/zones/<?php out($zone->name, ESC_URL)?>" class="zoneedit">
+<form method="post" action="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>" class="zoneedit">
 	<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 	<?php if(count($modifications['add']) > 0) { ?>
 	<h2>New resource recordsets</h2>
@@ -33,6 +33,7 @@ $limit = 2500;
 			<tr>
 				<th class="name">Name</th>
 				<th class="type">Type</th>
+				<th class="ttl">TTL</th>
 				<th>Data</th>
 				<th>Comments</th>
 				<th class="confirm">Okay to add?</th>
@@ -47,10 +48,11 @@ $limit = 2500;
 			<tr>
 				<td><?php out(DNSName::abbreviate($mod['new']->name, $zone->name))?></td>
 				<td><?php out($mod['new']->type)?></td>
+				<td><?php out(DNSTime::abbreviate($mod['new']->ttl))?></td>
 				<td>
 					<ul class="plain">
 						<?php foreach($mod['new']->list_resource_records() as $rr) { ?>
-						<li><?php out('TTL: '.DNSTime::abbreviate($rr->ttl).', Content: '.$rr->content.', Enabled: '.($rr->disabled ? 'No' : 'Yes')) ?></li>
+						<li><?php out('Content: '.$rr->content.', Enabled: '.($rr->disabled ? 'No' : 'Yes')) ?></li>
 						<?php } ?>
 					</ul>
 				</td>
@@ -74,6 +76,7 @@ $limit = 2500;
 			<tr>
 				<th class="name">Name</th>
 				<th class="type">Type</th>
+				<th class="ttl">TTL</th>
 				<th>Changes</th>
 				<th class="confirm">Okay to update?</th>
 			</tr>
@@ -87,6 +90,7 @@ $limit = 2500;
 			<tr>
 				<td><?php out(DNSName::abbreviate($mod['new']->name, $zone->name))?></td>
 				<td><?php out($mod['new']->type)?></td>
+				<td><?php out(DNSTime::abbreviate($mod['new']->ttl))?></td>
 				<td>
 					<ul class="plain">
 						<?php foreach($mod['changelist'] as $change) { ?>
@@ -107,6 +111,7 @@ $limit = 2500;
 			<tr>
 				<th class="name">Name</th>
 				<th class="type">Type</th>
+				<th class="ttl">TTL</th>
 				<th>Data</th>
 				<th>Comments</th>
 				<th class="confirm">Okay to delete?</th>
@@ -121,10 +126,11 @@ $limit = 2500;
 			<tr>
 				<td><?php out(DNSName::abbreviate($mod['old']->name, $zone->name))?></td>
 				<td><?php out($mod['old']->type)?></td>
+				<td><?php out(DNSTime::abbreviate($mod['old']->ttl))?></td>
 				<td>
 					<ul class="plain">
 						<?php foreach($mod['old']->list_resource_records() as $rr) { ?>
-						<li><?php out('TTL: '.DNSTime::abbreviate($rr->ttl).', Content: '.$rr->content) ?></li>
+						<li><?php out('Content: '.$rr->content) ?></li>
 						<?php } ?>
 					</ul>
 				</td>
@@ -149,7 +155,7 @@ $limit = 2500;
 	<?php } ?>
 	<p>
 		<button type="submit" name="update_rrs" value="1" class="btn btn-primary">Confirm selected changes</button>
-		<a href="/zones/<?php out($zone->name, ESC_URL)?>" class="btn btn-default">Cancel import</a>
+		<a href="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>" class="btn btn-default">Cancel import</a>
 	</p>
 </form>
 <?php } ?>

--- a/templates/zones.php
+++ b/templates/zones.php
@@ -21,9 +21,9 @@ $ns_templates = $this->get('ns_templates');
 $zone_types = array('forward' => array(), 'reverse4' => array(), 'reverse6' => array());
 $accounts = array();
 foreach($zones as $zone) {
-	if(substr($zone->name, -13) == '.in-addr.arpa') {
+	if(substr($zone->name, -14) == '.in-addr.arpa.') {
 		$zone_types['reverse4'][] = $zone;
-	} elseif(substr($zone->name, -9) == '.ip6.arpa') {
+	} elseif(substr($zone->name, -10) == '.ip6.arpa.') {
 		$zone_types['reverse6'][] = $zone;
 	} else {
 		$zone_types['forward'][] = $zone;
@@ -59,7 +59,7 @@ foreach($zones as $zone) {
 			<tbody>
 				<?php foreach($zone_types['forward'] as $zone) { ?>
 				<tr>
-					<td class="name"><a href="/zones/<?php out($zone->name, ESC_URL)?>"><?php out(idn_to_utf8($zone->name, 0, INTL_IDNA_VARIANT_UTS46))?></a></td>
+					<td class="name"><a href="/zones/<?php out(DNSZoneName::unqualify($zone->name, ESC_URL))?>"><?php out(DNSZoneName::unqualify(idn_to_utf8($zone->name, 0, INTL_IDNA_VARIANT_UTS46)))?></a></td>
 					<td><?php out($zone->serial)?></td>
 					<td><?php out($zone->account)?></td>
 				</tr>
@@ -86,7 +86,7 @@ foreach($zones as $zone) {
 			<tbody>
 				<?php foreach($zone_types['reverse4'] as $zone) { ?>
 				<tr>
-					<td class="name"><a href="/zones/<?php out($zone->name, ESC_URL)?>"><?php out($zone->name)?></a></td>
+					<td class="name"><a href="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>"><?php out(DNSZoneName::unqualify($zone->name))?></a></td>
 					<td><?php out(ipv4_reverse_zone_to_range($zone->name))?></td>
 					<td><?php out(ipv4_reverse_zone_to_subnet($zone->name))?></td>
 					<td><?php out($zone->serial)?></td>
@@ -120,7 +120,7 @@ foreach($zones as $zone) {
 			<tbody>
 				<?php foreach($zone_types['reverse6'] as $zone) { ?>
 				<tr>
-					<td class="name"><a href="/zones/<?php out($zone->name, ESC_URL)?>"><?php out($zone->name)?></a></td>
+					<td class="name"><a href="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>"><?php out(DNSZoneName::unqualify($zone->name))?></a></td>
 					<td><tt><?php out(ipv6_reverse_zone_to_range($zone->name))?></tt></td>
 					<td><?php out(ipv6_reverse_zone_to_subnet($zone->name))?></td>
 					<td><?php out($zone->serial)?></td>

--- a/templates/zonesplit.php
+++ b/templates/zonesplit.php
@@ -21,8 +21,8 @@ $suffix = $this->get('suffix');
 $split = $this->get('split');
 $cname_error = $this->get('cname_error');
 ?>
-<h2>Zone split of <?php out(idn_to_utf8($newzonename, 0, INTL_IDNA_VARIANT_UTS46))?> from <?php out(idn_to_utf8($zone->name, 0, INTL_IDNA_VARIANT_UTS46))?></h2>
-<form method="post" action="/zones/<?php out($zone->name, ESC_URL)?>/split">
+<h2>Zone split of <?php out(idn_to_utf8(DNSZoneName::unqualify($newzonename), 0, INTL_IDNA_VARIANT_UTS46))?> from <?php out(idn_to_utf8(DNSZoneName::unqualify($zone->name), 0, INTL_IDNA_VARIANT_UTS46))?></h2>
+<form method="post" action="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>/split">
 	<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 	<?php if(count($split) == 0) { ?>
 	<p>No records match this pattern.</p>
@@ -54,8 +54,8 @@ $cname_error = $this->get('cname_error');
 				if($newname == '@' && $rrset->type == 'CNAME') $rowclasses[] = 'danger';
 				?>
 			<tr class="<?php out(implode(' ', $rowclasses))?>">
-				<td class="align-right nowrap" rowspan="<?php out(count($rrs))?>"><strong><?php out(idn_to_utf8($name, 0, INTL_IDNA_VARIANT_UTS46))?></strong><span class="text-muted">.<?php out(idn_to_utf8($zone->name, 0, INTL_IDNA_VARIANT_UTS46))?></span></td>
-				<td class="align-right nowrap" rowspan="<?php out(count($rrs))?>"><strong><?php out(idn_to_utf8($newname, 0, INTL_IDNA_VARIANT_UTS46))?></strong><span class="text-muted">.<?php out(idn_to_utf8($newzonename, 0, INTL_IDNA_VARIANT_UTS46))?></span></td>
+				<td class="align-right nowrap" rowspan="<?php out(count($rrs))?>"><strong><?php out(idn_to_utf8($name, 0, INTL_IDNA_VARIANT_UTS46))?></strong><span class="text-muted">.<?php out(idn_to_utf8(DNSZoneName::unqualify($zone->name), 0, INTL_IDNA_VARIANT_UTS46))?></span></td>
+				<td class="align-right nowrap" rowspan="<?php out(count($rrs))?>"><strong><?php out(idn_to_utf8($newname, 0, INTL_IDNA_VARIANT_UTS46))?></strong><span class="text-muted">.<?php out(idn_to_utf8(DNSZoneName::unqualify($newzonename), 0, INTL_IDNA_VARIANT_UTS46))?></span></td>
 				<td rowspan="<?php out(count($rrs))?>"><?php out($rrset->type)?></td>
 				<?php
 				$count = 0;
@@ -93,7 +93,7 @@ $cname_error = $this->get('cname_error');
 		<?php if(!$cname_error) { ?>
 		<button type="submit" name="confirm" value="1" class="btn btn-primary">Split records into new zone</button>
 		<?php } ?>
-		<a href="/zones/<?php out($zone->name, ESC_URL)?>" class="btn btn-default">Cancel</a>
+		<a href="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>" class="btn btn-default">Cancel</a>
 	</div>
 	<?php } ?>
 </form>

--- a/templates/zonesplitcompleted.php
+++ b/templates/zonesplitcompleted.php
@@ -18,8 +18,8 @@
 $zone = $this->get('zone');
 $newzonename = $this->get('newzonename');
 ?>
-<h2>Zone split of <?php out(idn_to_utf8($newzonename, 0, INTL_IDNA_VARIANT_UTS46))?> from <?php out(idn_to_utf8($zone->name, 0, INTL_IDNA_VARIANT_UTS46))?></h2>
+<h2>Zone split of <?php out(idn_to_utf8(DNSZoneName::unqualify($newzonename), 0, INTL_IDNA_VARIANT_UTS46))?> from <?php out(idn_to_utf8(DNSZoneName::unqualify($zone->name), 0, INTL_IDNA_VARIANT_UTS46))?></h2>
 <ul>
-	<li><a href="/zones/<?php out(urlencode($zone->name))?>">View <?php out(idn_to_utf8($zone->name, 0, INTL_IDNA_VARIANT_UTS46))?> zone</a></li>
-	<li><a href="/zones/<?php out(urlencode($newzonename))?>">View <?php out(idn_to_utf8($newzonename, 0, INTL_IDNA_VARIANT_UTS46))?> zone</a></li>
+	<li><a href="/zones/<?php out(urlencode(DNSZoneName::unqualify($zone->name)))?>">View <?php out(idn_to_utf8(DNSZoneName::unqualify($zone->name), 0, INTL_IDNA_VARIANT_UTS46))?> zone</a></li>
+	<li><a href="/zones/<?php out(urlencode(DNSZoneName::unqualify($newzonename)))?>">View <?php out(idn_to_utf8(DNSZoneName::unqualify($newzonename), 0, INTL_IDNA_VARIANT_UTS46))?> zone</a></li>
 </ul>

--- a/views/api.php
+++ b/views/api.php
@@ -118,10 +118,10 @@ class API {
 			$rrs_data = new StdClass;
 			$rrs_data->name = DNSName::abbreviate($rrset->name, $zone->name);
 			$rrs_data->type = $rrset->type;
+			$rrs_data->ttl = DNSTime::abbreviate($rrset->ttl);
 			$rrs_data->records = array();
 			foreach($rrset->list_resource_records() as $rr) {
 				$rr_data = new StdClass;
-				$rr_data->ttl = DNSTime::abbreviate($rr->ttl);
 				$rr_data->content = DNSContent::decode($rr->content, $rrset->type);
 				$rr_data->enabled = !$rr->disabled;
 				$rrs_data->records[] = $rr_data;
@@ -197,12 +197,12 @@ class API {
 					$c_data->{$state} = new StdClass;
 					$c_data->{$state}->name = idn_to_utf8($rrset->name, 0, INTL_IDNA_VARIANT_UTS46);
 					$c_data->{$state}->type = $rrset->type;
+					$c_data->{$state}->ttl = DNSTime::abbreviate($rrset->ttl);
 					$c_data->{$state}->rrs = array();
 					$c_data->{$state}->comment = $rrset->merge_comment_text();
 					$rrs = $rrset->list_resource_records();
 					foreach($rrs as $rr) {
 						$rr_data = new StdClass;
-						$rr_data->ttl = DNSTime::abbreviate($rr->ttl);
 						$rr_data->content = DNSContent::decode($rr->content, $rr->type);
 						$rr_data->enabled = !$rr->disabled;
 						$c_data->{$state}->rrs[] = $rr_data;
@@ -216,7 +216,7 @@ class API {
 
 	public function created($url) {
 		header('HTTP/1.1 201 Created');
-		header('Location: /api/v1'.$url);
+		header('Location: /api/v2'.$url);
 		exit;
 	}
 

--- a/views/zoneexport.php
+++ b/views/zoneexport.php
@@ -16,7 +16,7 @@
 ##
 
 try {
-	$zone = $zone_dir->get_zone_by_name($router->vars['name']);
+	$zone = $zone_dir->get_zone_by_name($router->vars['name'].'.');
 } catch(ZoneNotFound $e) {
 	require('views/error404.php');
 	exit;
@@ -33,5 +33,5 @@ $page = new PageSection('zoneexport');
 $page->set('zone', $zone);
 $page->set('rrsets', $rrsets);
 header('Content-type: text/plain; charset=utf-8');
-header('Content-disposition: attachment; filename='.$zone->name);
+header('Content-disposition: attachment; filename='.DNSZoneName::unqualify($zone->name));
 echo $page->generate();

--- a/views/zonesplit.php
+++ b/views/zonesplit.php
@@ -16,7 +16,7 @@
 ##
 
 try {
-	$zone = $zone_dir->get_zone_by_name($router->vars['name']);
+	$zone = $zone_dir->get_zone_by_name($router->vars['name'].'.');
 } catch(ZoneNotFound $e) {
 	require('views/error404.php');
 	exit;
@@ -59,12 +59,12 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 				$newzone->add_resource_record_set($rrset);
 			}
 			$soa = new ResourceRecord;
-			$soa->ttl = $zone->soa->ttl;
 			$soa->content = $zone->soa->content;
 			$soa->disabled = false;
 			$soaset = new ResourceRecordSet;
 			$soaset->name = $newzonename;
 			$soaset->type = 'SOA';
+			$soaset->ttl = $zone->soa->ttl;
 			$soaset->add_resource_record($soa);
 			$newzone->add_resource_record_set($soaset);
 			try {
@@ -95,7 +95,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 				}
 				$zone_dir->git_tracked_export(array($zone), $git_commit_comment);
 				$alert = new UserAlert;
-				$alert->content = "Zone split of {$newzonename} from {$zone->name} has been completed.";
+				$alert->content = "Zone split of ".DNSZoneName::unqualify($newzonename)." from ".DNSZoneName::unqualify($zone->name)." has been completed.";
 				$active_user->add_alert($alert);
 				$content = new PageSection('zonesplitcompleted');
 				$content->set('zone', $zone);


### PR DESCRIPTION
The PowerDNS API brings some major changes:
* Zone data returned for a zone GET request now has records and comments organized by RRSet instead of individual RRs (this is a much better design, since we essentially had to work around the bad design before).
* All domain names are passed to and from the API as dot-qualified (ie. bind-like).
* TTL is now defined on a per-RRSet instead of a per-RR basis.

As well as one minor change:
* API path changed to `/api/v1`

With these major changes come also major changes to the DNS UI. The change that required the most patching is that the DNS UI now treats zone names as dot-qualified internally (but not in URLs and display).

The changes also necessitate a version bump of the DNS UI REST API and the removal of the old version (providing backwards compatibility for this is not worth the effort involved).