### PR TITLE
Simplify working with hostnames in resource record contents

### DIFF
--- a/model/zone.php
+++ b/model/zone.php
@@ -549,10 +549,8 @@ class Zone extends Record {
 			$trash[$update->name.' '.$update->type] = false;
 			foreach($update->records as $record) {
 				if(!(isset($record->content) && isset($record->enabled))) throw new BadData('Malformed record.');
-				$record->content = DNSContent::encode($record->content, $update->type);
+				$record->content = DNSContent::encode($record->content, $update->type, $this->name);
 				$rr = new ResourceRecord;
-				$rr->name = $update->name;
-				$rr->type = $update->type;
 				$rr->content = $record->content;
 				$rr->disabled = ($record->enabled === 'No' || $record->enabled === false);
 				$rr->{'set-ptr'} = $rr->disabled ? false : $zone_dir->check_reverse_record_zone($rr->type, $rr->content, $revs_missing, $revs_updated);
@@ -586,10 +584,8 @@ class Zone extends Record {
 			foreach($update->records as $record) {
 				if(!empty($record->delete)) continue;
 				$record_count++;
-				$record->content = DNSContent::encode($record->content, $update->type);
+				$record->content = DNSContent::encode($record->content, $update->type, $this->name);
 				$rr = new ResourceRecord;
-				$rr->name = $update->name;
-				$rr->type = $update->type;
 				$rr->content = $record->content;
 				$rr->disabled = ($record->enabled === 'No' || $record->enabled === false);
 				$rr->{'set-ptr'} = $zone_dir->check_reverse_record_zone($rr->type, $rr->content, $revs_missing, $revs_updated);

--- a/public_html/extra.js
+++ b/public_html/extra.js
@@ -154,6 +154,7 @@ $(function() {
 
 		// Convert the table cell content into a text input
 		function inputify(element) {
+			$('span.zone-hint', element).remove();
 			var text = element.text();
 			var input = document.createElement('input');
 			input.type = 'text';
@@ -227,7 +228,7 @@ $(function() {
 						var span = document.createElement('span');
 						span.appendChild(document.createTextNode('Added new resource record, Content = '));
 						var em = document.createElement('em');
-						$(em).text(content);
+						display_value(em, content, 'content', update.type);
 						span.appendChild(em);
 						span.appendChild(document.createTextNode(', Enabled = '));
 						var em = document.createElement('em');
@@ -281,13 +282,12 @@ $(function() {
 							var span = document.createElement('span');
 							$(span).text(ucname + ' changed from ');
 							var em = document.createElement('em');
-							$(em).text($(this).parent().data('oldvalue') || '""');
+							display_value(em, $(this).parent().data('oldvalue'), this.parentNode.className, update.type);
 							span.appendChild(em);
 							span.appendChild(document.createTextNode(' to '));
 							var em = document.createElement('em');
-							$(em).text($(this).val() || '""');
+							display_value(em, $(this).val(), this.parentNode.className, update.type);
 							span.appendChild(em);
-							span.appendChild(document.createTextNode('.'));
 							rrspan.appendChild(span);
 						}
 						switch(this.parentNode.className) {
@@ -439,6 +439,36 @@ $(function() {
 			} else {
 				$('#updates').show(200);
 				$(window).on('beforeunload', function() { return 'You have unsaved changes.'; });
+			}
+		}
+
+		/*
+		* Display the specified value inside the provided element. Show "" if the value is empty.
+		* Do some special processing for some cases.
+		*/
+		function display_value(element, value, value_type, record_type) {
+			$(element).text(value || '""');
+			if(value_type == 'content') {
+				switch(record_type) {
+				case 'CNAME':
+				case 'DNAME':
+				case 'NS':
+				case 'PTR':
+				case 'MX':
+				case 'SRV':
+					// Make it clear that without a trailing . we will automatically append
+					// the domain name to the content for these record types
+					if(value.endsWith('@')) {
+						var strong = document.createElement('strong');
+						$(strong).text(form.data('zone')).addClass('zone-hint');
+						element.appendChild(strong);
+					} else if(!value.endsWith('.')) {
+						var strong = document.createElement('strong');
+						$(strong).text('.' + form.data('zone')).addClass('zone-hint');
+						element.appendChild(strong);
+					}
+					break;
+				}
 			}
 		}
 

--- a/public_html/style.css
+++ b/public_html/style.css
@@ -187,6 +187,13 @@ del {
 .nowrap {
 	white-space: nowrap;
 }
+.zone-hint {
+	color: #bbb;
+}
+td:hover .zone-hint {
+	color: #999;
+}
+
 div.stickyHeader {
 	position: fixed;
 	top: 51px;

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -192,8 +192,9 @@ global $output_formatter;
 				</ul>
 				<input type="hidden" name="serial" value="<?php out($zone->soa->serial)?>">
 				<div class="form-group"><label for="comment">Update comment</label><input type="text" id="comment" name="comment" class="form-control"></div>
+				<div id="errors"></div>
 				<?php if($active_user->admin || $active_user->access_to($zone) == 'administrator') { ?>
-				<p><button type="submit" id="zonesubmit" name="update_rrs" value="1" class="btn btn-primary">Save changes</button></p>
+				<p><button type="button" id="zonesubmit" name="update_rrs" value="1" class="btn btn-primary">Save changes</button></p>
 				<?php } else { ?>
 				<p><button type="submit" id="zonesubmit" name="update_rrs" value="1" class="btn btn-primary">Request changes</button></p>
 				<?php } ?>

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -52,7 +52,7 @@ global $output_formatter;
 <div class="tab-content">
 	<div role="tabpanel" class="tab-pane active" id="records">
 		<h2 class="sr-only">Resource records</h2>
-		<form method="post" action="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>" class="zoneedit" data-local-zone="<?php out($local_zone ? 1 : 0)?>" data-local-ipv4-ranges="<?php out($local_ipv4_ranges)?>" data-local-ipv6-ranges="<?php out($local_ipv6_ranges)?>">
+		<form method="post" action="/zones/<?php out(DNSZoneName::unqualify($zone->name), ESC_URL)?>" class="zoneedit" data-zone="<?php out(punycode_to_utf8($zone->name))?>" data-local-zone="<?php out($local_zone ? 1 : 0)?>" data-local-ipv4-ranges="<?php out($local_ipv4_ranges)?>" data-local-ipv6-ranges="<?php out($local_ipv6_ranges)?>">
 			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 			<nav></nav>
 			<table class="table table-bordered table-condensed table-hover stickyHeader rrsets">
@@ -104,9 +104,25 @@ global $output_formatter;
 								}
 								out('>', ESC_NONE);
 							}
-							$rr->content = DNSContent::decode($rr->content, $rrset->type);
+							$rr->content = DNSContent::decode($rr->content, $rrset->type, $zone->name);
 							?>
-						<td class="content"><?php out($rr->content)?></td>
+						<td class="content"><?php
+							out($rr->content);
+							switch($rrset->type) {
+							case 'CNAME':
+							case 'DNAME':
+							case 'NS':
+							case 'PTR':
+							case 'MX':
+							case 'SRV':
+								if(substr($rr->content, -1) == '@') {
+									?><span class="zone-hint"><?php out("{$zone->name}");?></span><?php
+								} elseif(substr($rr->content, -1) != '.') {
+									?><span class="zone-hint"><?php out(".{$zone->name}");?></span><?php
+								}
+								break;
+							}
+						?></td>
 						<td class="enabled"><?php out($rr->disabled ? 'No' : 'Yes')?></td>
 						<td class="actions">
 							<button type="button" class="btn btn-default btn-xs delete-rr"><span class="glyphicon glyphicon-trash"></span> Delete</button>

--- a/templates/zonesplit.php
+++ b/templates/zonesplit.php
@@ -70,7 +70,7 @@ $cname_error = $this->get('cname_error');
 						}
 						out('>', ESC_NONE);
 					}
-					$rr->content = DNSContent::decode($rr->content, $rrset->type);
+					$rr->content = DNSContent::decode($rr->content, $rrset->type, $zone->name);
 					?>
 				<td><?php out(DNSTime::abbreviate($rr->ttl))?></td>
 				<td><?php out($rr->content)?></td>

--- a/views/api.php
+++ b/views/api.php
@@ -145,6 +145,7 @@ class API {
 		if(!$active_user->admin && !$active_user->access_to($zone)) throw new AccessDenied;
 		$json = file_get_contents('php://input');
 		$zone->process_bulk_json_rrset_update($json);
+		$this->output(null);
 	}
 
 	public function zone_changes($zone_name) {

--- a/views/api.php
+++ b/views/api.php
@@ -122,7 +122,7 @@ class API {
 			$rrs_data->records = array();
 			foreach($rrset->list_resource_records() as $rr) {
 				$rr_data = new StdClass;
-				$rr_data->content = DNSContent::decode($rr->content, $rrset->type);
+				$rr_data->content = DNSContent::decode($rr->content, $rrset->type, $zone_name);
 				$rr_data->enabled = !$rr->disabled;
 				$rrs_data->records[] = $rr_data;
 			}
@@ -203,7 +203,7 @@ class API {
 					$rrs = $rrset->list_resource_records();
 					foreach($rrs as $rr) {
 						$rr_data = new StdClass;
-						$rr_data->content = DNSContent::decode($rr->content, $rr->type);
+						$rr_data->content = DNSContent::decode($rr->content, $rr->type, $zone_name);
 						$rr_data->enabled = !$rr->disabled;
 						$c_data->{$state}->rrs[] = $rr_data;
 					}

--- a/views/zoneimport.php
+++ b/views/zoneimport.php
@@ -195,7 +195,7 @@ function import_bind9_zonefile($zone, $lines, $comment_handling) {
 				$ttl = DNSTime::expand($record->ttl);
 				$type = $record->type;
 				try {
-					$content = DNSContent::encode(DNSContent::from_bind9($record->content, $type, $zone->name), $type);
+					$content = DNSContent::encode($record->content, $type, $zone->name);
 				} catch(ErrorException $e) {
 					if($disabled) {
 						// We tried to parse something that looked like a commented-out record, but it was probably just a comment
@@ -414,7 +414,7 @@ function build_json($action, $rrset, $zonename) {
 		$data->records = array();
 		foreach($rrset->list_resource_records() as $rr) {
 			$rr_data = new StdClass;
-			$rr_data->content = DNSContent::decode($rr->content, $rrset->type);
+			$rr_data->content = DNSContent::decode($rr->content, $rrset->type, $zonename);
 			$rr_data->enabled = $rr->disabled ? 'No' : 'Yes';
 			$data->records[] = $rr_data;
 		}


### PR DESCRIPTION
Allows the use of '@' and auto-appends zonenames to unqualified hostnames.
Makes it clear through the UI when the auto-append does or will happen.