### PR TITLE
Fixing "ErrorException: ldap_bind(): Unable to bind to server: Protoc…

### DIFF
--- a/ldap.php
+++ b/ldap.php
@@ -37,6 +37,7 @@ class LDAP {
 			if(!ldap_start_tls($this->conn)) throw new LDAPConnectionFailureException('Could not initiate TLS connection to LDAP server');
 		}
 		if(!empty($this->bind_dn)) {
+			ldap_set_option($this->conn, LDAP_OPT_PROTOCOL_VERSION, 3);
 			if(!ldap_bind($this->conn, $this->bind_dn, $this->bind_password)) throw new LDAPConnectionFailureException('Could not bind to LDAP server');
 		}
 	}


### PR DESCRIPTION
…ol error in ldap.php:40" when using LDAP protocol 3

```
ErrorException: ldap_bind(): Unable to bind to server: Protocol error in /var/www/html/ldap.php:40, referer: http://localhost/zones
Stack trace:, referer: http://localhost/zones
#0 [internal function]: exception_error_handler(2, 'ldap_bind(): Un...', '/var/www/html/l...', 40, Array), referer: http://localhost/zones
#1 /var/www/html/ldap.php(40): ldap_bind(Resource id #19, 'cn=admin,dc=exa...', 'admin'), referer: http://localhost/zones
#2 /var/www/html/ldap.php(45): LDAP->connect(), referer: http://localhost/zones
#3 /var/www/html/model/user.php(118): LDAP->search('ou=users,dc=exa...', 'uid=admin', Array), referer: http://localhost/zones
#4 /var/www/html/model/userdirectory.php(93): User->get_details_from_ldap(), referer: http://localhost/zones
#5 /var/www/html/requesthandler.php(24): UserDirectory->get_user_by_uid('admin'), referer: http://localhost/zones
#6 /var/www/html/public_html/init.php(18): require('/var/www/html/r...'), referer: http://localhost/zones
#7 {main}, referer: http://localhost/zones
```