### PR TITLE
Return changeset info when update a zone

### DIFF
--- a/model/zone.php
+++ b/model/zone.php
@@ -525,7 +525,7 @@ class Zone extends Record {
 		$alert = new UserAlert;
 		$alert->content = "Zone updated successfully.";
 		$active_user->add_alert($alert);
-		return array("change_id" => $changeset->id);
+		return array("zone" => $this->name,"changelog_id" => $changeset->id, "missing_ptr_zone" => $revs_missing, "updated_ptr_zone" => $revs_updated );
 	}
 
 	/**
@@ -536,6 +536,7 @@ class Zone extends Record {
 	* @param array $revs_updated keep track of reverse zones that will be updated
 	*/
 	private function process_rrset_action($update, &$trash, &$revs_missing, &$revs_updated) {
+
 		global $active_user, $zone_dir;
 		if(!is_object($update)) throw new BadData('Malformed update.');
 		if(!(isset($update->name) && isset($update->type))) throw new BadData('Malformed action.');

--- a/model/zone.php
+++ b/model/zone.php
@@ -536,7 +536,6 @@ class Zone extends Record {
 	* @param array $revs_updated keep track of reverse zones that will be updated
 	*/
 	private function process_rrset_action($update, &$trash, &$revs_missing, &$revs_updated) {
-
 		global $active_user, $zone_dir;
 		if(!is_object($update)) throw new BadData('Malformed update.');
 		if(!(isset($update->name) && isset($update->type))) throw new BadData('Malformed action.');

--- a/model/zone.php
+++ b/model/zone.php
@@ -525,6 +525,7 @@ class Zone extends Record {
 		$alert = new UserAlert;
 		$alert->content = "Zone updated successfully.";
 		$active_user->add_alert($alert);
+		return array("change_id" => $changeset->id);
 	}
 
 	/**

--- a/model/zone.php
+++ b/model/zone.php
@@ -467,6 +467,7 @@ class Zone extends Record {
 	/**
 	* Given a JSON-encoded string with a list of changes to be made to a zone, process and perform those changes.
 	* @param string $update JSON-encoded list of changes
+	* @return array with data ptr zone changes and the changeset->id
 	*/
 	public function process_bulk_json_rrset_update($update, $author = null) {
 		global $active_user, $config, $zone_dir;
@@ -525,7 +526,12 @@ class Zone extends Record {
 		$alert = new UserAlert;
 		$alert->content = "Zone updated successfully.";
 		$active_user->add_alert($alert);
-		return array("zone" => $this->name,"changelog_id" => $changeset->id, "missing_ptr_zone" => $revs_missing, "updated_ptr_zone" => $revs_updated );
+
+		return array(
+				"missing_ptr_zone" => $revs_missing, 
+				"updated_ptr_zone" => $revs_updated,
+				"changes_id" => $changeset->id
+			    );
 	}
 
 	/**

--- a/model/zonedirectory.php
+++ b/model/zonedirectory.php
@@ -207,7 +207,7 @@ class ZoneDirectory extends DBDirectory {
 	* @param array $revs_missing keep track of reverse zones that are missing
 	* @param array $revs_updated keep track of reverse zones that will be updated
 	*/
-	public function check_reverse_record_zone($type, $address, &$revs_missing, &$revs_notify) {
+	public function check_reverse_record_zone($type, $address, &$revs_missing, &$revs_updated) {
 		global $zone_dir, $active_user;
 
 		if($type == 'A') {
@@ -236,7 +236,7 @@ class ZoneDirectory extends DBDirectory {
 					}
 				}
 				// Add reverse zone to list of zones to send a notify for
-				$revs_notify[$reverse_zone->pdns_id] = $reverse_zone;
+				$revs_updated[$reverse_zone->pdns_id] = $reverse_zone;
 				return true;
 			} catch(ZoneNotFound $e) {
 			}

--- a/views/api.php
+++ b/views/api.php
@@ -144,8 +144,8 @@ class API {
 		$zone = $zone_dir->get_zone_by_name($zone_name);
 		if(!$active_user->admin && !$active_user->access_to($zone)) throw new AccessDenied;
 		$json = file_get_contents('php://input');
-		$zone->process_bulk_json_rrset_update($json);
-		$this->output(null);
+		$changeid = $zone->process_bulk_json_rrset_update($json);
+		$this->output($changeid);
 	}
 
 	public function zone_changes($zone_name) {

--- a/views/api.php
+++ b/views/api.php
@@ -144,8 +144,8 @@ class API {
 		$zone = $zone_dir->get_zone_by_name($zone_name);
 		if(!$active_user->admin && !$active_user->access_to($zone)) throw new AccessDenied;
 		$json = file_get_contents('php://input');
-		$changeid = $zone->process_bulk_json_rrset_update($json);
-		$this->output($changeid);
+		$changeset = $zone->process_bulk_json_rrset_update($json);
+		$this->output($changeset);
 	}
 
 	public function zone_changes($zone_name) {


### PR DESCRIPTION
Fiddling around with a cli to interact with the API. 

But I discovered that when patch I get null as payload. I've here added to return changeset->id + if ptr zones are missing and the ones updated. 

Why? So I can review what changes my patch did when only interact with API.