### PR TITLE
Fix redirect

### DIFF
--- a/core.php
+++ b/core.php
@@ -143,6 +143,7 @@ function redirect($url = null, $type = '303 See other') {
 	if(is_null($url)) $url = $absolute_request_url;
 	header("HTTP/1.1 $type");
 	header("Location: $url");
+	print("\n");
 	exit;
 }
 


### PR DESCRIPTION
I really don't understand why I needed this 'fix', but without it
the redirect header is never sent and the application is broken.

```
curl -v -uafisher http://pdns-01c.example.com
Enter host password for user 'afisher':
* About to connect() to pdns-01c.example.com port 80 (#0)
*   Trying 192.168.1.1...
* Connected to pdns-01c.example.com (192.168.1.1) port 80 (#0)
* Server auth using Basic with user 'afisher'
> GET / HTTP/1.1
> Authorization: Basic REDACTED==
> User-Agent: curl/7.29.0
> Host: pdns-01c.example.com
> Accept: */*
>
* Empty reply from server
* Connection #0 to host pdns-01c.example.com left intact
curl: (52) Empty reply from server
```

I'm using CentOS 7.4 with PHP 7.1 from
https://rpms.remirepo.net/enterprise/7/php71/x86_64/repoview/

No documentation I could find suggests the existing code is wrong.
It *should* work.  I'm not sure if it's my php version or a php.ini
setting, but for me at least this hack is needed.

It should be a harmless change, but I understand if you don't want
to merge without a better explanation!