### PR TITLE
Exception when there are no zones present

### DIFF
--- a/templates/zones.php
+++ b/templates/zones.php
@@ -203,13 +203,9 @@ foreach($zones as $zone) {
 			<div class="form-group">
 				<label for="dnssec" class="col-sm-2 control-label">DNSSEC</label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin) { ?>
 					<div class="checkbox">
-						<label><input type="checkbox" id="dnssec" name="dnssec" value="1"<?php if($zone->dnssec) out(' checked')?>> Enabled</label>
+						<label><input type="checkbox" id="dnssec" name="dnssec" value="1"> Enabled</label>
 					</div>
-					<?php } else { ?>
-					<p class="form-control-static"><?php out($zone->dnssec ? 'Enabled' : 'Disabled')?></p>
-					<?php } ?>
 				</div>
 			</div>
 			<?php } ?>


### PR DESCRIPTION
When there are no zones in powerdns, an exception is thrown on the zones page:

ErrorException: Undefined variable: zone in templates/zones.php:208

In the code at the 'Create zone' part, the current $zone is checked, which is not looped (and leaked from a previous loop). However, if the previous loop never ran (no zones exist), the variable is not set. This checking should not be there, as that's only for editing an existing zone.

Additionally, a check is performed if the user is admin, which also happens at the if on line 169, which includes this code as well, so it's redundant.