### PR TITLE
Add config option to control autocreation of reverse records

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -78,6 +78,10 @@ api_key = api_key
 ; Enable DNSSEC UI (requires PowerDNS 4.1)
 dnssec = 0
 
+; If enabled (the default), matching PTR records will be automatically created
+; when new A or AAAA records are added.
+autocreate_reverse_records = 1
+
 ; Space-separated lists
 local_zone_suffixes = "localdomain"
 local_ipv4_ranges = "10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 127.0.0.0/8"


### PR DESCRIPTION
This commit adds a configuration option to control whether reverse
records are automatically added when A or AAAA records are created. The
option is enabled by default in order to maintain backward
compatibility.