### PR TITLE
Fixed PHP syntax error in autocreate_ptr

### DIFF
--- a/model/zone.php
+++ b/model/zone.php
@@ -709,7 +709,7 @@ class Zone extends Record {
 			$rrset->ttl = DNSTime::expand($update->ttl);
 			$trash[$update->name.' '.$update->type] = false;
 			if(isset($config['dns']['autocreate_reverse_records'])) {
-				$autocreate_ptr = (bool)$config['dns']['autocreate_reverse_records']);
+				$autocreate_ptr = (bool)$config['dns']['autocreate_reverse_records'];
 			} else {
 				$autocreate_ptr = true; # enabled by default
 			}


### PR DESCRIPTION
The fix in PR #47 contains a PHP syntax error:

ParseError: syntax error, unexpected ')' in model/zone.php:712