### PR TITLE
Adding option to enforce change review

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -5,6 +5,8 @@ baseurl = https://dns.example.com
 logo = /logo-header-opera.png
 ; footer may contain HTML. Literal & " < and > should be escaped as &amp; &quot; &lt; $gt;
 footer = 'Developed by <a href="https://www.opera.com/">Opera Software</a>.'
+; Enable this option if you want system and zone admins to be forced to request changes just like the operators.
+;force_change_review = 1
 
 [email]
 enabled = 1

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -29,6 +29,7 @@ $local_ipv6_ranges = $this->get('local_ipv6_ranges');
 $soa_templates = $this->get('soa_templates');
 $dnssec_enabled = $this->get('dnssec_enabled');
 $deletion = $this->get('deletion');
+$force_change_review = $this->get('force_change_review');
 $maxperpage = 1000;
 $reverse = false;
 global $output_formatter;
@@ -201,7 +202,7 @@ global $output_formatter;
 				<input type="hidden" name="serial" value="<?php out($zone->soa->serial)?>">
 				<div class="form-group"><label for="comment">Update comment</label><input type="text" id="comment" name="comment" class="form-control"></div>
 				<div id="errors"></div>
-				<?php if($active_user->admin || $active_user->access_to($zone) == 'administrator') { ?>
+				<?php if(($active_user->admin || $active_user->access_to($zone) == 'administrator') && !$force_change_review) { ?>
 				<p><button type="submit" id="zonesubmit" name="update_rrs" value="save" class="btn btn-primary">Save changes</button></p>
 				<?php } else { ?>
 				<p><button type="submit" id="zonesubmit" name="update_rrs" value="request" class="btn btn-primary">Request changes</button></p>

--- a/views/zone.php
+++ b/views/zone.php
@@ -58,6 +58,7 @@ $access = $zone->list_access();
 $accounts = $zone_dir->list_accounts();
 $allusers = $user_dir->list_users();
 $replication_types = $replication_type_dir->list_replication_types();
+$force_change_review = isset($config['web']['force_change_review']) ? $config['web']['force_change_review'] : '0';
 
 if($_SERVER['REQUEST_METHOD'] == 'POST') {
 	if(isset($_POST['update_rrs'])) {
@@ -69,7 +70,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 		foreach($_POST['updates'] as $update) {
 			$json->actions[] = json_decode($update);
 		}
-		if($active_user->admin || $active_user->access_to($zone) == 'administrator') {
+		if(($active_user->admin || $active_user->access_to($zone) == 'administrator') && !$force_change_review) {
 			try {
 				$zone->process_bulk_json_rrset_update(json_encode($json));
 				redirect();
@@ -284,6 +285,7 @@ if(!isset($content)) {
 	$content->set('soa_templates', $template_dir->list_soa_templates());
 	$content->set('dnssec_enabled', isset($config['dns']['dnssec']) ? $config['dns']['dnssec'] : '0');
 	$content->set('deletion', $deletion);
+	$content->set('force_change_review', $force_change_review);
 }
 
 $page = new PageSection('base');


### PR DESCRIPTION
The new option changes the behavior of the UI in regards to how changes
are saved or requested. By default force_change_review is disabled and
admin users can save their zone changes immediately without the need to
request changes, like before. But in some cases it may be desirable to
subject all changes to review and even admin users will need to request
changes, just like the operators. The admin users can still approve their
own changes.

See also: #49