### PR TITLE
Ensuring consistent SOA_EDIT behaviour for Master/Slave replication.

### DIFF
--- a/model/zone.php
+++ b/model/zone.php
@@ -589,6 +589,7 @@ class Zone extends Record {
 			}
 			$data->rrsets[] = $recordset;
 		}
+		$data->soa_edit = 'INCEPTION-INCREMENT';
 		$data->soa_edit_api = 'INCEPTION-INCREMENT';
 		$data->account = $this->account;
 		$data->dnssec = (bool)$this->dnssec;

--- a/model/zonedirectory.php
+++ b/model/zonedirectory.php
@@ -99,6 +99,7 @@ class ZoneDirectory extends DBDirectory {
 			}
 			$data->rrsets[] = $recordset;
 		}
+		$data->soa_edit = 'INCEPTION-INCREMENT';
 		$data->soa_edit_api = 'INCEPTION-INCREMENT';
 		$data->account = $zone->account;
 		$data->dnssec = (bool)$zone->dnssec;


### PR DESCRIPTION
Because not all changes are guarranteed to reach PowerDNS master via the
API, and some may happend via other means SOA_EDIT should be also set on
zone creation and have the same value of SOA_EDIT_API.

Without this, the zones created via dns-ui will get the SOA_EDIT value
from the PowerDNS master server configuration default-soa-edit, which may not
be INCEPTION-INCREMENT.

See also: #55