### PR TITLE
Adding alternative user data source based on PHP_AUTH_ variables.

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -26,7 +26,12 @@ dsn = "pgsql:host=localhost dbname=dnsui"
 username = username
 password = password
 
+[php_auth]
+enabled = 0
+admin_group = "systems"
+
 [ldap]
+enabled = 1
 ; Address to connect to LDAP server
 host = ldaps://ldap.example.com:636
 ; Use StartTLS for connection security (recommended if using ldap:// instead of ldaps:// above)

--- a/core.php
+++ b/core.php
@@ -40,12 +40,14 @@ require('powerdns.php');
 require('email.php');
 require('bindzonefile.php');
 
-$ldap = new LDAP(
-	isset($config['ldap']['host']) ? $config['ldap']['host'] : $config['ldap']['hostname'],
-	isset($config['ldap']['starttls']) ? $config['ldap']['starttls'] : 1,
-	$config['ldap']['bind_dn'],
-	$config['ldap']['bind_password']
-);
+if(!empty($config['ldap']['enabled'])) {
+	$ldap = new LDAP(
+		isset($config['ldap']['host']) ? $config['ldap']['host'] : $config['ldap']['hostname'],
+		isset($config['ldap']['starttls']) ? $config['ldap']['starttls'] : 1,
+		$config['ldap']['bind_dn'],
+		$config['ldap']['bind_password']
+	);
+}
 setup_database();
 
 // Convert all non-fatal errors into exceptions

--- a/migrations/006.php
+++ b/migrations/006.php
@@ -1,0 +1,5 @@
+<?php
+$migration_name = 'Add PHP_AUTH support';
+
+// Add new value PHP_AUTH to enum type auth_realm.
+$this->database->exec("ALTER TYPE auth_realm ADD VALUE 'PHP_AUTH'");

--- a/model/migrationdirectory.php
+++ b/model/migrationdirectory.php
@@ -22,7 +22,7 @@ class MigrationDirectory extends DBDirectory {
 	/**
 	* Increment this constant to activate a new migration from the migrations directory
 	*/
-	const LAST_MIGRATION = 5;
+	const LAST_MIGRATION = 6;
 
 	public function __construct() {
 		parent::__construct();

--- a/model/userdirectory.php
+++ b/model/userdirectory.php
@@ -95,7 +95,7 @@ class UserDirectory extends DBDirectory {
 			$user = new User;
 			$user->uid = $uid;
 			$this->cache_uid[$uid] = $user;
-			$user->get_details_from_ldap();
+			$user->get_details();
 			$this->add_user($user);
 		}
 		return $user;
@@ -138,4 +138,5 @@ class UserDirectory extends DBDirectory {
 }
 
 class UserNotFoundException extends Exception {}
+class UserDataSourceException extends Exception {}
 class UserAlreadyExistsException extends Exception {}


### PR DESCRIPTION
As an alternative to LDAP, user data can now be found in the following PHP variables:
PHP_AUTH_NAME - the full name of the user
PHP_AUTH_EMAIL - the email address of the user
PHP_AUTH_GROUPS - the list of groups the user is a member of, separated by spaces

A configuration section [php_auth] was added and a `enabled` flag was added to [ldap] section.
Only one data source can be enabled, either ldap or php_auth.
The `admin_group` option defines the criteria for selection of administrative users.
Only the users that have the `admin_group` value in their group list will be created on the database as administrators.

The PHP variables mentioned have to be passed from the web server to the PHP application, like PHP_AUTH_USER.
The single sign on module on the web server has to be configured to get the required data and pass the values to such variables.