### PR TITLE
Additional required PHP modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Requirements
 * PHP 5.6+
 * PHP intl (Internationalization Functions) extension
 * PHP JSON extension
+* PHP CURL extension
+* PHP Multibyte String extension
 * PHP LDAP extension
 * PHP PDO_PGSQL extension
 * PostgreSQL database


### PR DESCRIPTION
During building a development environment, I ran into a couple of requirements for DNS UI which were not in the README.md, which threw some PHP errors when they were not installed.