### PR TITLE
Enable API-RECTIFY when enabling DNSSEC and warn for existing zones without it

### DIFF
--- a/model/zone.php
+++ b/model/zone.php
@@ -44,6 +44,10 @@ class Zone extends Record {
 	*/
 	private $cryptokeys = null;
 	/**
+	* Flag for API-RECTIFY being enabled
+	*/
+	private $api_rectify = null;
+	/**
 	* List of changes to be applied to the zone when doing ->commit_changes()
 	*/
 	private $changes = array();
@@ -67,6 +71,9 @@ class Zone extends Record {
 		case 'nameservers':
 			if(is_null($this->nameservers)) $this->list_resource_record_sets();
 			return $this->nameservers;
+		case 'api_rectify':
+			if(is_null($this->api_rectify)) $this->list_resource_record_sets();
+			return $this->api_rectify;
 		default:
 			return parent::__get($field);
 		}
@@ -81,6 +88,9 @@ class Zone extends Record {
 		switch($field) {
 		case 'nameservers':
 			$this->nameservers = $value;
+			break;
+		case 'api_rectify':
+			$this->api_rectify = $value;
 			break;
 		default:
 			parent::__set($field, $value);
@@ -194,6 +204,7 @@ class Zone extends Record {
 		$update->account = $this->account;
 		if(isset($config['dns']['dnssec']) && $config['dns']['dnssec'] == 1) {
 			$update->dnssec = (bool)$this->dnssec;
+			$update->api_rectify = (bool)$this->api_rectify;
 		}
 		$response = $this->powerdns->put('zones/'.urlencode($this->pdns_id), $update);
 		parent::update();
@@ -283,6 +294,9 @@ class Zone extends Record {
 					unset($this->rrsets[$key]);
 					error_log("Stray comment for $key in zone {$this->name}");
 				}
+			}
+			if(isset($data->api_rectify)) {
+				$this->api_rectify = $data->api_rectify;
 			}
 		}
 		return $this->rrsets;

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -483,6 +483,15 @@ global $output_formatter;
 	<div role="tabpanel" class="tab-pane" id="dnssec">
 		<h2 class="sr-only">DNSSEC</h2>
 		<?php if($zone->dnssec) { ?>
+		<?php if(!$zone->api_rectify && $active_user->admin) { ?>
+		<form method="post" action="<?php outurl('/zones/'.urlencode(DNSZoneName::unqualify($zone->name)))?>">
+			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
+			<div class="alert alert-warning">
+				<p><strong>Warning:</strong> API-rectify is not enabled for this zone. It is recommended to enable it so that manual DNSSEC rectification is not needed.</p>
+				<p><button type="submit" class="btn btn-success" name="enable_api_rectify" value="1">Enable API-rectify</button></p>
+			</div>
+		</form>
+		<?php } ?>
 		<h3>Crypto keys</h3>
 		<?php foreach($cryptokeys as $cryptokey) { ?>
 		<?php

--- a/views/zone.php
+++ b/views/zone.php
@@ -210,6 +210,11 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 		redirect();
 	} elseif(isset($_POST['enable_dnssec']) && $active_user->admin) {
 		$zone->dnssec = 1;
+		$zone->api_rectify = 1;
+		$zone->update();
+		redirect();
+	} elseif(isset($_POST['enable_api_rectify']) && $active_user->admin) {
+		$zone->api_rectify = 1;
 		$zone->update();
 		redirect();
 	} elseif(isset($_POST['disable_dnssec']) && $active_user->admin) {


### PR DESCRIPTION
Also provides UI for enabling API-RECTIFY for a DNSSEC-enabled zone.

Resolves: #69