### PR TITLE
Mention that baseurl should not include trailing slash

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -1,6 +1,7 @@
 ; DNS UI config file
 [web]
 enabled = 1
+; Do not include a trailing / in the baseurl
 baseurl = https://dns.example.com
 logo = /logo-header-opera.png
 ; footer may contain HTML. Literal & " < and > should be escaped as &amp; &quot; &lt; $gt;

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -157,6 +157,7 @@ global $output_formatter;
 								-->
 								<?php if($reverse) { ?>
 								<option value="CNAME" data-content-pattern="\S+">CNAME</option>
+								<option value="DS" data-content-pattern="[0-9]+\s+[0-9]+\s+[0-9]+\s+[a-zA-Z0-9]+">DS</option>
 								<?php if($active_user->admin) { ?>
 								<option value="NS" data-content-pattern="\S*">NS</option>
 								<?php } ?>


### PR DESCRIPTION
New pull request with valid GPG signature.

Also allow DS record type in reverse zones.

Resolves: #73, #72 