### PR TITLE
Fixed random HTTPS redirects

### DIFF
--- a/requesthandler.php
+++ b/requesthandler.php
@@ -31,7 +31,7 @@ $base_path = dirname(__FILE__);
 $base_url = dirname($_SERVER['SCRIPT_NAME']);
 $request_url = preg_replace('|(.)/$|', '$1', $_SERVER['REQUEST_URI']);
 $relative_request_url = preg_replace('/^'.preg_quote($base_url, '/').'/', '/', $request_url);
-$absolute_request_url = 'http'.(isset($_SERVER['HTTPS']) ? 's' : '').'://'.$_SERVER['HTTP_HOST'].$request_url;
+$absolute_request_url = 'http'.(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != '' ? 's' : '').'://'.$_SERVER['HTTP_HOST'].$request_url;
 
 if(empty($config['web']['enabled'])) {
 	require('views/error503.php');

--- a/requesthandler.php
+++ b/requesthandler.php
@@ -31,7 +31,7 @@ $base_path = dirname(__FILE__);
 $base_url = dirname($_SERVER['SCRIPT_NAME']);
 $request_url = preg_replace('|(.)/$|', '$1', $_SERVER['REQUEST_URI']);
 $relative_request_url = preg_replace('/^'.preg_quote($base_url, '/').'/', '/', $request_url);
-$absolute_request_url = 'http'.(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != '' ? 's' : '').'://'.$_SERVER['HTTP_HOST'].$request_url;
+$absolute_request_url = 'http'.(empty($_SERVER['HTTPS']) ? '' : 's').'://'.$_SERVER['HTTP_HOST'].$request_url;
 
 if(empty($config['web']['enabled'])) {
 	require('views/error503.php');


### PR DESCRIPTION
$_SERVER['HTTPS'] must be set AND contain something to treat connection as secure. http://php.net/manual/pl/reserved.variables.server.php states:
  'HTTPS'
    Set to a non-empty value if the script was queried through the HTTPS protocol.