### PR TITLE
Fix autofill for SOA on zone edit

### DIFF
--- a/templates/zone.php
+++ b/templates/zone.php
@@ -443,10 +443,10 @@ global $output_formatter;
 				</div>
 			</div>
 			<div class="form-group">
-				<label for="expiry" class="col-sm-2 control-label"><abbr title="Indicates when the zone data is no longer authoritative. Used by Slave (Secondary) servers only.">Expiry</abbr></label>
+				<label for="expire" class="col-sm-2 control-label"><abbr title="Indicates when the zone data is no longer authoritative. Used by Slave (Secondary) servers only.">Expire</abbr></label>
 				<div class="col-sm-10">
 					<?php if($active_user->admin) { ?>
-					<input type="text" class="form-control" id="expiry" name="expiry" required pattern="([0-9]+[smhdwSMHDW]?)+" maxlength="40" value="<?php out(DNSTime::abbreviate($zone->soa->expiry))?>">
+					<input type="text" class="form-control" id="expire" name="expire" required pattern="([0-9]+[smhdwSMHDW]?)+" maxlength="40" value="<?php out(DNSTime::abbreviate($zone->soa->expiry))?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out(DNSTime::abbreviate($zone->soa->expiry))?></p>
 					<?php } ?>

--- a/views/zone.php
+++ b/views/zone.php
@@ -182,7 +182,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 		$contact = $_POST['contact'];
 		$refresh = DNSTime::expand($_POST['refresh']);
 		$retry = DNSTime::expand($_POST['retry']);
-		$expiry = DNSTime::expand($_POST['expiry']);
+		$expiry = DNSTime::expand($_POST['expire']);
 		$default_ttl = DNSTime::expand($_POST['default_ttl']);
 		$soa_ttl = DNSTime::expand($_POST['soa_ttl']);
 		if($zone->soa->primary_ns != $primary_ns


### PR DESCRIPTION
When editing a zone, the "Expire" field isn't updated when hitting the template button as there is a inconsistent wording across the templates and the whole model.

This commit changes the wording from "Expiry" to "Expire" on zone edit page to be consistent with zone create and template page.

HTML names and ids have been changed accordingly