### PR TITLE
Generate absolute_request_url based on configured baseurl

### DIFF
--- a/core.php
+++ b/core.php
@@ -51,6 +51,7 @@ if(!empty($config['ldap']['enabled'])) {
 setup_database();
 
 $relative_frontend_base_url = (string)parse_url($config['web']['baseurl'], PHP_URL_PATH);
+$frontend_root_url = preg_replace('/'.preg_quote($relative_frontend_base_url, '/').'$/', '', $config['web']['baseurl']);
 
 // Convert all non-fatal errors into exceptions
 function exception_error_handler($errno, $errstr, $errfile, $errline) {

--- a/requesthandler.php
+++ b/requesthandler.php
@@ -30,7 +30,7 @@ if(isset($_SERVER['PHP_AUTH_USER'])) {
 $base_path = dirname(__FILE__);
 $request_url = preg_replace('|(.)/$|', '$1', $_SERVER['REQUEST_URI']);
 $relative_request_url = preg_replace('/^'.preg_quote($relative_frontend_base_url, '/').'/', '', $request_url) ?: '/';
-$absolute_request_url = 'http'.(empty($_SERVER['HTTPS']) ? '' : 's').'://'.$_SERVER['HTTP_HOST'].$request_url;
+$absolute_request_url = $frontend_root_url.$request_url;
 
 if(empty($config['web']['enabled'])) {
 	require('views/error503.php');


### PR DESCRIPTION
Instead of using data from $_SERVER. Makes reverse proxying easier as no need for ProxyPassReverse or similar.

See also: #102