### PR TITLE
Make header text configurable

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -4,7 +4,8 @@ enabled = 1
 ; Do not include a trailing / in the baseurl
 baseurl = https://dns.example.com
 logo = /logo-header-opera.png
-; footer may contain HTML. Literal & " < and > should be escaped as &amp; &quot; &lt; $gt;
+; header and footer may contain HTML. Literal & " < and > should be escaped as &amp; &quot; &lt; $gt;
+header = 'DNS management'
 footer = 'Developed by <a href="https://www.opera.com/">Opera Software</a>.'
 ; Enable this option if you want system and zone admins to be forced to request changes just like the operators.
 ;force_change_review = 1

--- a/templates/base.php
+++ b/templates/base.php
@@ -40,7 +40,11 @@ header("Content-Security-Policy: default-src 'self'");
 			<?php if(!empty($web_config['logo'])) { ?>
 			<a class="navbar-brand" href="<?php outurl('/')?>">
 				<img src="<?php out($web_config['logo'])?>">
+				<?php if(!empty($web_config['header'])) { ?>
+				<?php out($web_config['header'], ESC_NONE)?>
+				<?php } else { ?>
 				DNS management
+				<?php } ?>
 			</a>
 			<?php } ?>
 		</div>


### PR DESCRIPTION
Hi! We're using the DNS-UI at work and have made a few improvements/changes that we'd like to bring back upstream.  This is the first of three pull requests, but all of them are independent from one another and should apply on top of master cleanly in any order.

We're happy to make any changes suggested in order to get our patches merged. Any feedback is welcome!

## Commit Message

This is useful for example to differentiate preproduction from
production servers or servers managing different databases.
This is a logical extension of the already configurable logo and footer
text.

## Notes

I've made it so that when the newly introduced configuration option `[web]header` does not exist in the existing user config.ini, it will fall back to use the previous value of "DNS management". 
This change is important to us to differentiate preproduction from production environments at a glance.