### PR TITLE
optionally allow case-insensitive user names

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -29,6 +29,10 @@ dsn = "pgsql:host=localhost dbname=dnsui"
 username = username
 password = password
 
+[authentication]
+; compare the user ID's case? (on by default)
+user_case_sensitive = 1
+
 [php_auth]
 enabled = 0
 admin_group = "systems"

--- a/model/userdirectory.php
+++ b/model/userdirectory.php
@@ -82,10 +82,18 @@ class UserDirectory extends DBDirectory {
 	* @throws UserNotFoundException if no user with that uid exists
 	*/
 	public function get_user_by_uid($uid) {
+		global $config;
+		if(isset($config['authentication']['user_case_sensitive']) && $config['authentication']['user_case_sensitive'] == 0) {
+			$uid = mb_strtolower($uid);
+			$sql_statement = 'SELECT * FROM "user" WHERE lower(uid) = ?';
+		} else {
+			$sql_statement = 'SELECT * FROM "user" WHERE uid = ?';
+		}
+
 		if(isset($this->cache_uid[$uid])) {
 			return $this->cache_uid[$uid];
 		}
-		$stmt = $this->database->prepare('SELECT * FROM "user" WHERE uid = ?');
+		$stmt = $this->database->prepare($sql_statement);
 		$stmt->bindParam(1, $uid, PDO::PARAM_STR);
 		$stmt->execute();
 		if($row = $stmt->fetch(PDO::FETCH_ASSOC)) {


### PR DESCRIPTION
Here comes PR 2 of 3! Again, we're happy to make any changes suggested in order to get our patches merged. Any feedback is welcome!

## Commit Message

Case sensitive user names can be a problem in certain Active Directory
environments. With this patch, user names (e.g. LDAP common names) may
be compared case insensitively by setting the configuration value
[authentication]user_case_sensitive to 0. Note that this affects all
login methods, not just LDAP.

## Notes

This obsoletes / closes PR #150, which was opened just last week, but appears to not work with LDAP backends and modifies files (user.php) unnecessarily.