### PR TITLE
allow DNSSEC UI to be accessed read-only

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -94,8 +94,10 @@ api_url = "http://localhost:8081/api/v1/servers/localhost"
 api_key = api_key
 
 [dns]
-; Enable DNSSEC UI (requires PowerDNS 4.1)
+; Enable DNSSEC UI and enable editing (requires PowerDNS 4.1)
 dnssec = 0
+; Enable DNSSEC UI for reading only (requires PowerDNS 4.1)
+dnssec_readonly = 0
 
 ; If enabled (the default), matching PTR records will be automatically created
 ; when new A or AAAA records are added.

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -29,6 +29,7 @@ $local_ipv4_ranges = $this->get('local_ipv4_ranges');
 $local_ipv6_ranges = $this->get('local_ipv6_ranges');
 $soa_templates = $this->get('soa_templates');
 $dnssec_enabled = $this->get('dnssec_enabled');
+$dnssec_readonly = $this->get('dnssec_readonly');
 $deletion = $this->get('deletion');
 $force_change_review = $this->get('force_change_review');
 $force_change_comment = $this->get('force_change_comment');
@@ -50,7 +51,7 @@ global $output_formatter;
 	<li role="presentation" class="active"><a href="#records" aria-controls="records" role="tab" data-toggle="tab">Resource records</a></li>
 	<li role="presentation"><a href="#pending" aria-controls="pending" role="tab" data-toggle="tab">Pending updates<?php if(count($pending) > 0) {?> <span class="badge"><?php out(count($pending))?></span><?php } ?></a></li>
 	<li role="presentation"><a href="#soa" aria-controls="soa" role="tab" data-toggle="tab">Zone configuration</a></li>
-	<?php if($dnssec_enabled) { ?>
+	<?php if($dnssec_enabled || $dnssec_readonly) { ?>
 	<li role="presentation"><a href="#dnssec" aria-controls="dnssec" role="tab" data-toggle="tab">DNSSEC</a></li>
 	<?php } ?>
 	<li role="presentation"><a href="#import" aria-controls="import" role="tab" data-toggle="tab">Export / Import</a></li>
@@ -502,7 +503,7 @@ global $output_formatter;
 			<?php } ?>
 		</form>
 	</div>
-	<?php if($dnssec_enabled) { ?>
+	<?php if($dnssec_enabled || $dnssec_readonly) { ?>
 	<div role="tabpanel" class="tab-pane" id="dnssec">
 		<h2 class="sr-only">DNSSEC</h2>
 		<?php if($zone->dnssec) { ?>
@@ -547,6 +548,7 @@ global $output_formatter;
 		<?php } else { ?>
 		<p>DNSSEC is not currently enabled for this zone.</p>
 		<?php } ?>
+		<?php if($dnssec_enabled) { ?>
 		<?php if($active_user->admin) { ?>
 		<?php if($zone->dnssec) { ?>
 		<h3>Disable DNSSEC</h3>
@@ -568,6 +570,7 @@ global $output_formatter;
 				<button type="submit" name="enable_dnssec" value="1" class="btn btn-primary">Enable DNSSEC for <?php out(DNSZoneName::unqualify($zone->name))?></button>
 			</p>
 		</form>
+		<?php } ?>
 		<?php } ?>
 		<?php } ?>
 	</div>

--- a/templates/zones.php
+++ b/templates/zones.php
@@ -22,6 +22,7 @@ $ns_templates = $this->get('ns_templates');
 $dnssec_enabled = $this->get('dnssec_enabled');
 $account_whitelist = $this->get('account_whitelist');
 $force_account_whitelist = $this->get('force_account_whitelist');
+$dnssec_readonly = $this->get('dnssec_readonly');
 $zone_types = array('forward' => array(), 'reverse4' => array(), 'reverse6' => array());
 $accounts = array();
 foreach($zones as $zone) {
@@ -59,7 +60,7 @@ foreach($zones as $zone) {
 					<th>Serial</th>
 					<th>Replication type</th>
 					<th>Classification</th>
-					<?php if($dnssec_enabled) { ?>
+					<?php if($dnssec_enabled || $dnssec_readonly) { ?>
 					<th>DNSSEC</th>
 					<?php } ?>
 				</tr>
@@ -74,7 +75,7 @@ foreach($zones as $zone) {
 					<td class="serial"><?php out($zone->serial)?></td>
 					<td class="kind"><?php out($zone->kind)?></td>
 					<td class="account"><?php out($zone->account)?></td>
-					<?php if($dnssec_enabled) { ?>
+					<?php if($dnssec_enabled || $dnssec_readonly) { ?>
 					<td class="dnssec<?php if($zone->dnssec) out(' success') ?>"><?php out($zone->dnssec ? 'Enabled' : 'Disabled')?></td>
 					<?php } ?>
 				</tr>
@@ -97,7 +98,7 @@ foreach($zones as $zone) {
 					<th>Serial</th>
 					<th>Replication type</th>
 					<th>Classification</th>
-					<?php if($dnssec_enabled) { ?>
+					<?php if($dnssec_enabled || $dnssec_readonly) { ?>
 					<th>DNSSEC</th>
 					<?php } ?>
 				</tr>
@@ -114,7 +115,7 @@ foreach($zones as $zone) {
 					<td class="serial"><?php out($zone->serial)?></td>
 					<td class="kind"><?php out($zone->kind)?></td>
 					<td class="account"><?php out($zone->account)?></td>
-					<?php if($dnssec_enabled) { ?>
+					<?php if($dnssec_enabled || $dnssec_readonly) { ?>
 					<td class="dnssec<?php if($zone->dnssec) out(' success') ?>"><?php out($zone->dnssec ? 'Enabled' : 'Disabled')?></td>
 					<?php } ?>
 				</tr>
@@ -144,7 +145,7 @@ foreach($zones as $zone) {
 					<th>Serial</th>
 					<th>Replication type</th>
 					<th>Classification</th>
-					<?php if($dnssec_enabled) { ?>
+					<?php if($dnssec_enabled || $dnssec_readonly) { ?>
 					<th>DNSSEC</th>
 					<?php } ?>
 				</tr>
@@ -161,7 +162,7 @@ foreach($zones as $zone) {
 					<td class="serial"><?php out($zone->serial)?></td>
 					<td class="kind"><?php out($zone->kind)?></td>
 					<td class="account"><?php out($zone->account)?></td>
-					<?php if($dnssec_enabled) { ?>
+					<?php if($dnssec_enabled || $dnssec_readonly) { ?>
 					<td class="dnssec<?php if($zone->dnssec) out(' success') ?>"><?php out($zone->dnssec ? 'Enabled' : 'Disabled')?></td>
 					<?php } ?>
 				</tr>

--- a/views/zone.php
+++ b/views/zone.php
@@ -303,6 +303,7 @@ if(!isset($content)) {
 	$content->set('local_ipv6_ranges', $config['dns']['local_ipv6_ranges']);
 	$content->set('soa_templates', $template_dir->list_soa_templates());
 	$content->set('dnssec_enabled', isset($config['dns']['dnssec']) ? $config['dns']['dnssec'] : '0');
+	$content->set('dnssec_readonly', isset($config['dns']['dnssec_readonly']) ? $config['dns']['dnssec_readonly'] : '0');
 	$content->set('deletion', $deletion);
 	$content->set('force_change_review', $force_change_review);
 	$content->set('force_change_comment', $force_change_comment);

--- a/views/zones.php
+++ b/views/zones.php
@@ -73,6 +73,7 @@ if(!isset($content)) {
 	$content->set('dnssec_enabled', isset($config['dns']['dnssec']) ? $config['dns']['dnssec'] : '0');
 	$content->set('account_whitelist', $account_whitelist);
 	$content->set('force_account_whitelist', $force_account_whitelist);
+	$content->set('dnssec_readonly', isset($config['dns']['dnssec_readonly']) ? $config['dns']['dnssec_readonly'] : '0');
 }
 
 $page = new PageSection('base');


### PR DESCRIPTION
Finally, the last of the three pull requests. Again, we're happy to make any changes suggested in order to get our patches merged. Any feedback is welcome!

## Notes

We are using PowerDNS and set DNSSEC manually on some zones, so we need to be able to see if a zone has it enabled or not. But having the big red and blue buttons is risky, as one might accidentally change DNSSEC settings, breaking stuff.

I've opted to overload the existing `[dns]dnssec` config option with a special value `ro`, but I'm happy to change that to a new pref as well. This way was chosen as it makes it backwards compatible and the patch very simple. 