### PR TITLE
Apply data-* attributes to table columns for user defined styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config/config.ini
+public_html/site.css
 extensions/*.php
 vagrant/*.retry
 vagrant/*.log

--- a/templates/base.php
+++ b/templates/base.php
@@ -24,6 +24,9 @@ header("Content-Security-Policy: default-src 'self'");
 <link rel="stylesheet" href="<?php outurl('/bootstrap/css/bootstrap.min.css')?>">
 <link rel="stylesheet" href="<?php outurl('/bootstrap/css/bootstrap-theme.min.css')?>">
 <link rel="stylesheet" href="<?php outurl('/style.css?'.filemtime('public_html/style.css'))?>">
+<?php if(is_file("public_html/site.css")) { ?>
+<link rel="stylesheet" href="<?php outurl('/site.css?'.filemtime('public_html/site.css'))?>">
+<?php } ?>
 <link rel="icon" href="<?php outurl('/book_next.png')?>">
 <title><?php out($this->get('title'))?></title>
 <?php out($this->get('head'), ESC_NONE) ?>

--- a/templates/zones.php
+++ b/templates/zones.php
@@ -66,16 +66,16 @@ foreach($zones as $zone) {
 			</thead>
 			<tbody>
 				<?php foreach($zone_types['forward'] as $zone) { ?>
-				<tr>
+				<tr data-name="<?php out(DNSZoneName::unqualify($zone->name))?>" data-serial="<?php out($zone->serial)?>" data-kind="<?php out($zone->kind)?>" data-account="<?php out($zone->account)?>" data-dnssec="<?php out($zone->dnssec)?>">
 					<td class="name">
 						<?php if($zone->pending_updates > 0) { ?><a href="<?php outurl('/zones/'.urlencode(DNSZoneName::unqualify($zone->name)))?>#pending"><span class="badge"><?php out(number_format($zone->pending_updates))?></span></a><?php } ?>
 						<a href="<?php outurl('/zones/'.urlencode(DNSZoneName::unqualify($zone->name)))?>"><?php out(DNSZoneName::unqualify($zone->name))?></a>
 					</td>
-					<td><?php out($zone->serial)?></td>
-					<td><?php out($zone->kind)?></td>
-					<td><?php out($zone->account)?></td>
+					<td class="serial"><?php out($zone->serial)?></td>
+					<td class="kind"><?php out($zone->kind)?></td>
+					<td class="account"><?php out($zone->account)?></td>
 					<?php if($dnssec_enabled) { ?>
-					<td<?php if($zone->dnssec) out(' class="success"', ESC_NONE) ?>><?php out($zone->dnssec ? 'Enabled' : 'Disabled')?></td>
+					<td class="dnssec<?php if($zone->dnssec) out(' success') ?>"><?php out($zone->dnssec ? 'Enabled' : 'Disabled')?></td>
 					<?php } ?>
 				</tr>
 				<?php } ?>
@@ -104,18 +104,18 @@ foreach($zones as $zone) {
 			</thead>
 			<tbody>
 				<?php foreach($zone_types['reverse4'] as $zone) { ?>
-				<tr>
+				<tr data-name="<?php out(DNSZoneName::unqualify($zone->name))?>" data-ipv4-reverse-range="<?php out(ipv4_reverse_zone_to_range($zone->name))?>" data-ipv4-reverse-subnet="<?php out(ipv4_reverse_zone_to_subnet($zone->name))?>" data-serial="<?php out($zone->serial)?>" data-kind="<?php out($zone->kind)?>" data-account="<?php out($zone->account)?>" data-dnssec="<?php out($zone->dnssec)?>">
 					<td class="name">
 						<?php if($zone->pending_updates > 0) { ?><span class="badge"><?php out(number_format($zone->pending_updates))?></span><?php } ?>
 						<a href="<?php outurl('/zones/'.urlencode(DNSZoneName::unqualify($zone->name)))?>"><?php out(DNSZoneName::unqualify($zone->name))?></a>
 					</td>
-					<td><?php out(ipv4_reverse_zone_to_range($zone->name))?></td>
-					<td><?php out(ipv4_reverse_zone_to_subnet($zone->name))?></td>
-					<td><?php out($zone->serial)?></td>
-					<td><?php out($zone->kind)?></td>
-					<td><?php out($zone->account)?></td>
+					<td class="ipv4-reverse-range"><?php out(ipv4_reverse_zone_to_range($zone->name))?></td>
+					<td class="ipv4-reverse-subnet"><?php out(ipv4_reverse_zone_to_subnet($zone->name))?></td>
+					<td class="serial"><?php out($zone->serial)?></td>
+					<td class="kind"><?php out($zone->kind)?></td>
+					<td class="account"><?php out($zone->account)?></td>
 					<?php if($dnssec_enabled) { ?>
-					<td<?php if($zone->dnssec) out(' class="success"', ESC_NONE) ?>><?php out($zone->dnssec ? 'Enabled' : 'Disabled')?></td>
+					<td class="dnssec<?php if($zone->dnssec) out(' success') ?>"><?php out($zone->dnssec ? 'Enabled' : 'Disabled')?></td>
 					<?php } ?>
 				</tr>
 				<?php } ?>
@@ -151,18 +151,18 @@ foreach($zones as $zone) {
 			</thead>
 			<tbody>
 				<?php foreach($zone_types['reverse6'] as $zone) { ?>
-				<tr>
+				<tr data-name="<?php out(DNSZoneName::unqualify($zone->name))?>" data-ipv6-reverse-range="<?php out(ipv6_reverse_zone_to_range($zone->name))?>" data-ipv6-reverse-subnet="<?php out(ipv6_reverse_zone_to_subnet($zone->name))?>" data-serial="<?php out($zone->serial)?>" data-kind="<?php out($zone->kind)?>" data-account="<?php out($zone->account)?>" data-dnssec="<?php out($zone->dnssec)?>">
 					<td class="name">
 						<?php if($zone->pending_updates > 0) { ?><span class="badge"><?php out(number_format($zone->pending_updates))?></span><?php } ?>
 						<a href="<?php outurl('/zones/'.urlencode(DNSZoneName::unqualify($zone->name)))?>"><?php out(DNSZoneName::unqualify($zone->name))?></a>
 					</td>
-					<td><tt><?php out(ipv6_reverse_zone_to_range($zone->name))?></tt></td>
-					<td><?php out(ipv6_reverse_zone_to_subnet($zone->name))?></td>
-					<td><?php out($zone->serial)?></td>
-					<td><?php out($zone->kind)?></td>
-					<td><?php out($zone->account)?></td>
+					<td class="ipv6-reverse-range"><tt><?php out(ipv6_reverse_zone_to_range($zone->name))?></tt></td>
+					<td class="ipv6-reverse-subnet"><?php out(ipv6_reverse_zone_to_subnet($zone->name))?></td>
+					<td class="serial"><?php out($zone->serial)?></td>
+					<td class="kind"><?php out($zone->kind)?></td>
+					<td class="account"><?php out($zone->account)?></td>
 					<?php if($dnssec_enabled) { ?>
-					<td<?php if($zone->dnssec) out(' class="success"', ESC_NONE) ?>><?php out($zone->dnssec ? 'Enabled' : 'Disabled')?></td>
+					<td class="dnssec<?php if($zone->dnssec) out(' success') ?>"><?php out($zone->dnssec ? 'Enabled' : 'Disabled')?></td>
 					<?php } ?>
 				</tr>
 				<?php } ?>


### PR DESCRIPTION
Hi, we've got a fourth PR: This one will make it easy to apply user-defined styles on the zones tables. We use it for example to highlight different Classifications in different colours using this stylesheet. Again, we're happy to make any changes required to get this merged!

```
tr[data-account="internal"]>td.account {
  background-color: #d9edf7;
}
tr[data-account="internal"]:hover>td.account,
tr[data-account="internal"]>td.account:hover {
  background-color: #c4e3f3;
}
```
The a bit verbose `data-` attributes were chosen for maximum flexibility: a on-site-administrator can easily get at all the data and manipulate it with CSS (or even JavaScript).

The stylesheet could also be used to apply styles to the header and footer (we use it to distinguish between preproduction and production, for example).