### PR TITLE
Option to restrict Classification column to predetermined values

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -101,6 +101,10 @@ local_zone_suffixes = "localdomain"
 local_ipv4_ranges = "10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 127.0.0.0/8"
 local_ipv6_ranges = "fd00::/8 ::1/128"
 
+; if non-empty, only allow entering these (comma seperated) values in the Classification column
+; Note that this is purely a front-end restriction, designed to avoid accidental errors.
+;classification_whitelist = "internal,public"
+
 [git_tracked_export]
 ; If enabled, will export zones as bind9 zone format to the specified path and
 ; will git add / git commit on behalf of the active user.

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -32,6 +32,8 @@ $dnssec_enabled = $this->get('dnssec_enabled');
 $deletion = $this->get('deletion');
 $force_change_review = $this->get('force_change_review');
 $force_change_comment = $this->get('force_change_comment');
+$account_whitelist = $this->get('account_whitelist');
+$force_account_whitelist = $this->get('force_account_whitelist');
 $maxperpage = 1000;
 $reverse = false;
 global $output_formatter;
@@ -374,12 +376,23 @@ global $output_formatter;
 				<label for="classification" class="col-sm-2 control-label">Classification</label>
 				<div class="col-sm-10">
 					<?php if($active_user->admin) { ?>
+					<?php if($force_account_whitelist) { ?>
+					<select class="form-control" id="classification" name="classification">
+						<?php foreach($account_whitelist as $account) { ?>
+						<option value="<?php out($account)?>"<?php if($account == $zone->account) out(' selected', ESC_NONE)?>><?php out($account)?></option>
+						<?php } ?>
+						<?php if(!in_array($zone->account, $account_whitelist)) { ?>
+						<option value="<?php out($zone->account)?>" selected><?php out($zone->account)?></option>
+						<?php } ?>
+					</select>
+					<?php } else { ?>
 					<input type="text" class="form-control" id="classification" name="classification" list="account_list" required maxlength="40" value="<?php out($zone->account)?>">
 					<datalist id="account_list">
 						<?php foreach($accounts as $account) { ?>
 						<option value="<?php out($account)?>"><?php out($account)?></option>
 						<?php } ?>
 					</datalist>
+					<?PHP } ?>
 					<?php } else { ?>
 					<p class="form-control-static"><?php out($zone->account)?></p>
 					<?php } ?>

--- a/templates/zones.php
+++ b/templates/zones.php
@@ -20,6 +20,8 @@ $replication_types = $this->get('replication_types');
 $soa_templates = $this->get('soa_templates');
 $ns_templates = $this->get('ns_templates');
 $dnssec_enabled = $this->get('dnssec_enabled');
+$account_whitelist = $this->get('account_whitelist');
+$force_account_whitelist = $this->get('force_account_whitelist');
 $zone_types = array('forward' => array(), 'reverse4' => array(), 'reverse6' => array());
 $accounts = array();
 foreach($zones as $zone) {
@@ -200,12 +202,20 @@ foreach($zones as $zone) {
 			<div class="form-group">
 				<label for="classification" class="col-sm-2 control-label">Classification</label>
 				<div class="col-sm-10">
+					<?php if($force_account_whitelist) { ?>
+					<select class="form-control" id="classification" name="classification" required>
+						<?php foreach($account_whitelist as $account) { ?>
+						<option value="<?php out($account)?>"><?php out($account)?></option>
+						<?php } ?>
+					</select>
+					<?php } else { ?>
 					<input type="text" class="form-control" id="classification" name="classification" required list="account_list" maxlength="40">
 					<datalist id="account_list">
 						<?php foreach($accounts as $account) { ?>
 						<option value="<?php out($account)?>"><?php out($account)?></option>
 						<?php } ?>
 					</datalist>
+					<?php } ?>
 				</div>
 			</div>
 			<?php if($dnssec_enabled) { ?>

--- a/views/zone.php
+++ b/views/zone.php
@@ -61,6 +61,8 @@ $allusers = $user_dir->list_users();
 $replication_types = $replication_type_dir->list_replication_types();
 $force_change_review = isset($config['web']['force_change_review']) ? intval($config['web']['force_change_review']) : 0;
 $force_change_comment = isset($config['web']['force_change_comment']) ? intval($config['web']['force_change_comment']) : 0;
+$account_whitelist = !empty($config['dns']['classification_whitelist']) ? explode(',', $config['dns']['classification_whitelist']) : [];
+$force_account_whitelist = !empty($config['dns']['classification_whitelist']) ? 1 : 0;
 
 if($_SERVER['REQUEST_METHOD'] == 'POST') {
 	if(isset($_POST['update_rrs'])) {
@@ -304,6 +306,8 @@ if(!isset($content)) {
 	$content->set('deletion', $deletion);
 	$content->set('force_change_review', $force_change_review);
 	$content->set('force_change_comment', $force_change_comment);
+	$content->set('account_whitelist', $account_whitelist);
+	$content->set('force_account_whitelist', $force_account_whitelist);
 }
 
 $page = new PageSection('base');

--- a/views/zones.php
+++ b/views/zones.php
@@ -25,6 +25,8 @@ usort($zones, function($a, $b) {
 $replication_types = $replication_type_dir->list_replication_types();
 $soa_templates = $template_dir->list_soa_templates();
 $ns_templates = $template_dir->list_ns_templates();
+$account_whitelist = !empty($config['dns']['classification_whitelist']) ? explode(',', $config['dns']['classification_whitelist']) : [];
+$force_account_whitelist = !empty($config['dns']['classification_whitelist']) ? 1 : 0;
 
 if($_SERVER['REQUEST_METHOD'] == 'POST') {
 	if(isset($_POST['add_zone']) && $active_user->admin) {
@@ -69,6 +71,8 @@ if(!isset($content)) {
 	$content->set('soa_templates', $soa_templates);
 	$content->set('ns_templates', $ns_templates);
 	$content->set('dnssec_enabled', isset($config['dns']['dnssec']) ? $config['dns']['dnssec'] : '0');
+	$content->set('account_whitelist', $account_whitelist);
+	$content->set('force_account_whitelist', $force_account_whitelist);
 }
 
 $page = new PageSection('base');


### PR DESCRIPTION
As with the previous pull requests, we're happy to implement any changes requested in order to get this merged. Thanks!

This adds a new config variable `classification_whitelist` (chosen so it matches the UI's naming), which restricts which values can be set in the classification field. Note that this is a front-end change only; it guards against accidental typos, not a predetermined sysadmin wanting to cause trouble ;-)

When editing a zone, there may be a non-whitelisted value already in the field. Then, this value will be temporarily added to just this zone's whitelist, so it can be saved correctly. Once the value gets changed to a whitelisted one, it can't be reverted (through the UI) to a non-whitelisted one. (hope that makes sense)