### PR TITLE
Bugfix: DNSSEC support for Split Zone

### DIFF
--- a/views/zonesplit.php
+++ b/views/zonesplit.php
@@ -53,6 +53,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 			$newzone = new Zone;
 			$newzone->name = $newzonename;
 			$newzone->account = $zone->account;
+			$newzone->dnssec = $zone->dnssec;
 			$newzone->kind = 'Master';
 			$newzone->nameservers = $zone->nameservers;
 			foreach($split as $rrset) {


### PR DESCRIPTION
When splitting a zone, the DNSSEC field was not set, causing NULLs in the
database. 

Once again, we're happy to make changes! Thanks!