### PR TITLE
Replaces variable `$base_path` with constant to avoid NullPointerExcption in `path_join()`.

### DIFF
--- a/core.php
+++ b/core.php
@@ -64,9 +64,8 @@ function exception_error_handler($errno, $errstr, $errfile, $errline) {
 
 // Autoload needed model files
 function autoload_model($classname) {
-	global $base_path;
 	$classname = preg_replace('/[^a-z]/', '', strtolower($classname)); # Prevent directory traversal and sanitize name
-	$filename = path_join($base_path, 'model', $classname.'.php');
+	$filename = path_join(BASE_PATH, 'model', $classname.'.php');
 	if(file_exists($filename)) {
 		include($filename);
 	}

--- a/requesthandler.php
+++ b/requesthandler.php
@@ -16,6 +16,7 @@
 ##
 
 chdir(dirname(__FILE__));
+define('BASE_PATH', __DIR__);
 require('core.php');
 ob_start();
 set_exception_handler('exception_handler');
@@ -27,7 +28,6 @@ if(isset($_SERVER['PHP_AUTH_USER'])) {
 }
 
 // Work out where we are on the server
-$base_path = dirname(__FILE__);
 $request_url = preg_replace('|(.)/$|', '$1', $_SERVER['REQUEST_URI']);
 $relative_request_url = preg_replace('/^'.preg_quote($relative_frontend_base_url, '/').'/', '', $request_url) ?: '/';
 $absolute_request_url = $frontend_root_url.$request_url;
@@ -58,7 +58,7 @@ foreach($routes as $path => $service) {
 }
 $router->handle_request($relative_request_url);
 if(isset($router->view)) {
-	$view = path_join($base_path, 'views', $router->view.'.php');
+	$view = path_join(BASE_PATH, 'views', $router->view.'.php');
 	if(file_exists($view)) {
 		require($view);
 	} else {

--- a/scripts/create_admin_account.php
+++ b/scripts/create_admin_account.php
@@ -17,6 +17,7 @@
 ##
 
 chdir(__DIR__);
+define('BASE_PATH', dirname(__DIR__));
 require('../core.php');
 
 echo "This script creates a new admin account in DNS UI.\n";

--- a/scripts/full_git_tracked_export.php
+++ b/scripts/full_git_tracked_export.php
@@ -17,6 +17,7 @@
 ##
 
 chdir(__DIR__);
+define('BASE_PATH', dirname(__DIR__));
 require('../core.php');
 
 // Use 'import' user as the active user (create if it does not yet exist)

--- a/scripts/ldap_update.php
+++ b/scripts/ldap_update.php
@@ -17,6 +17,7 @@
 ##
 
 chdir(__DIR__);
+define('BASE_PATH', dirname(__DIR__));
 require('../core.php');
 
 $users = $user_dir->list_users();


### PR DESCRIPTION
When running dns-ui under PHP 7.4.1 it will produce the following error:
```
Fatal error: Uncaught ErrorException: Trying to access array offset on value of type null in /var/www/dns-ui/core.php:102
Stack trace:
#0 /var/www/dns-ui/core.php(102): exception_error_handler(8, 'Trying to acces...', '/var/www/dns-ui...', 102, Array) 
#1 /var/www/dns-ui/core.php(69): path_join(NULL, 'model', 'migrationdirect...') 
#2 [internal function]: autoload_model('migrationdirect...') 
#3 /var/www/dns-ui/core.php(81): spl_autoload_call('MigrationDirect...') 
#4 /var/www/dns-ui/core.php(55): setup_database() 
#5 /var/www/dns-ui/requesthandler.php(19): require('/var/www/dns-ui...') 
#6 /var/www/dns-ui/public_html/init.php(18): require('/var/www/dns-ui...') 
#7 {main} thrown in /var/www/dns-ui/core.php on line 102
```
The reason about this is, that the variable `$base_path` is not available in `core.php`. This PR replaces this variable by a new constant `BASE_PATH` which is set before `core.php` is included.