### PR TITLE
add "expand/collapse all" button to zone changelog

### DIFF
--- a/public_html/style.css
+++ b/public_html/style.css
@@ -172,6 +172,13 @@ table.changelog table td.content {
 	word-break: break-all;
 }
 
+#changelog-expand-all, #changelog-collapse-all {
+	float: right;
+}
+#changelog-collapse-all {
+	display: none;
+}
+
 input[type=text]:focus:invalid, input[type=email]:focus:invalid, select:focus:invalid, textarea:focus:invalid {
 	box-shadow: 0 0 5px #d45252;
 	border-color: #b03535;

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -663,6 +663,8 @@ global $output_formatter;
 	<?php } ?>
 	<div role="tabpanel" class="tab-pane" id="changelog">
 		<h2 class="sr-only">Changelog</h2>
+		<button class="btn btn-default" id="changelog-expand-all">expand all</button>
+		<button class="btn btn-default" id="changelog-collapse-all">collapse all</button>
 		<?php if(count($changesets) == 0) { ?>
 		<p>No changes have been made to this zone.</p>
 		<?php } ?>


### PR DESCRIPTION
This makes it possible to Ctrl-F search a zone's changelog.

Most of the changes are indentation, since it was necessary to move the `show_changes()` and related functions outside the `$('table.changelog').each()`-block.

`show_changelog()` was called with a second parameter, but it did not accept such one--I assume, a remnant of a previous version. I have removed the parameter from this call, and replaced it with a new optional one,  which allows one to instead of toggling an entry, either show or hide it. 

As usual, happy to change anything and thanks for your maintenance.