### PR TITLE
Add DHCID record type

### DIFF
--- a/bindzonefile.php
+++ b/bindzonefile.php
@@ -43,7 +43,7 @@ class BindZonefile {
 		$line_number = 0;
 		$new_rrsets = array();
 		$new_rrset_comments = array();
-		$recordtypes = 'A|AAAA|ALIAS|CAA|CNAME|LOC|MX|NAPTR|NS|PTR|SOA|SRV|SSHFP|TXT';
+		$recordtypes = 'A|AAAA|ALIAS|CAA|CNAME|DHCID|LOC|MX|NAPTR|NS|PTR|SOA|SRV|SSHFP|TXT';
 		$mainregexp = '/^
 					   (;)?                                    # Starting semicolon, indicating commented-out (disabled) record
 					   (?:\s+|(\S+)\s+)                        # Record name, or whitespace to use same name as previous line

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -172,6 +172,8 @@ global $output_formatter;
 								<option value="ALIAS" data-content-pattern="\S+">ALIAS</option>
 								<option value="CAA" data-content-pattern="[0-9]+\s+\S+\s+\S+">CAA</option>
 								<option value="CNAME" data-content-pattern="\S+">CNAME</option>
+								<!-- DHCID regex contributed under CC BY-SA 4.0 by njzk2 (https://stackoverflow.com/users/671543/njzk2) on Stack Overflow: https://stackoverflow.com/a/5885097 -->
+								<option value="DHCID" data-content-pattern="^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$">DHCID</option>
 								<option value="DNAME" data-content-pattern="\S+">DNAME</option>
 								<option value="DNSKEY" data-content-pattern="[0-9]+\s+[0-9]+\s+[0-9]+\s+.+">DNSKEY</option>
 								<option value="DS" data-content-pattern="[0-9]+\s+[0-9]+\s+[0-9]+\s+[a-zA-Z0-9]+">DS</option>


### PR DESCRIPTION
These changes add support for importing bind9 zone files that contain DHCID
records [1], as well as validation of DHCID entries in the zone.php template.

[1] https://tools.ietf.org/html/rfc4701

The DHCID RDATA consists of a base64 string, hence the complicated regular expression. I have tested my changes against the DHCID records that we use at work as well as the example records provided by RFC 4701.