### PR TITLE
fix error on zone deletion & history function

### DIFF
--- a/model/zone.php
+++ b/model/zone.php
@@ -222,8 +222,10 @@ class Zone extends Record {
 			$this->nameservers = array();
 			try {
 				$data = $this->powerdns->get('zones/'.urlencode($this->pdns_id));
-			} catch(Pest_InvalidRecord $e) {
+			} catch(Pest_InvalidRecord $e) { // before PowerDNS 4.2
 				throw new ZoneNotFoundInPowerDNS;
+			} catch(Pest_NotFound $e) { // 404 since PowerDNS 4.2
+			    throw new ZoneNotFoundInPowerDNS;;
 			}
 			$possible_bad_data = array();
 			usort($data->rrsets,


### PR DESCRIPTION
Since PowerDNS 4.2.0-rc1 non existing zones will return 404 instead of 422 (https://github.com/PowerDNS/pdns/pull/6076) that results in "Oops" on dns-ui after zone deletion and breaks history page.
This commit maintains backward compatibility to versions before PowerDNS 4.2; also maintains code compatibility before PHP 7.1.

This fixes #160 