### PR TITLE
Don't raise and exception when trying to parse date without microseconds

### DIFF
--- a/core.php
+++ b/core.php
@@ -522,6 +522,14 @@ function log_exception($e) {
 	return $error_number;
 }
 
+function parse_postgres_date($date_str) {
+	// If the date's microsecond part is exactly zero, it is omitted by
+	// postgres from its string representation and '.u' must be removed
+	// from the format, or parsing will fail.
+	$date_format = strpos($date_str, '.') !== false ? 'Y-m-d H:i:s.u' : 'Y-m-d H:i:s';
+	return DateTime::createFromFormat($date_format, $date_str);
+}
+
 class AccessDenied extends RuntimeException {}
 class BadData extends RuntimeException {}
 class InvalidJSON extends RuntimeException {}

--- a/model/user.php
+++ b/model/user.php
@@ -250,7 +250,7 @@ class User extends Record {
 			unset($row['serial']);
 			unset($row['account']);
 			unset($row['active']);
-			$row['change_date'] = DateTime::createFromFormat('Y-m-d H:i:s.u', $row['change_date']);
+			$row['change_date'] = parse_postgres_date($row['change_date']);
 			$changesets[] = new ChangeSet($row['id'], $row);
 		}
 		return $changesets;

--- a/model/zone.php
+++ b/model/zone.php
@@ -351,7 +351,7 @@ class Zone extends Record {
 		while($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
 			$row['author'] = $user_dir->get_user_by_id($row['author_id']);
 			$row['requester'] = (is_null($row['requester_id']) ? null : $user_dir->get_user_by_id($row['requester_id']));
-			$row['change_date'] = DateTime::createFromFormat('Y-m-d H:i:s.u', $row['change_date']);
+			$row['change_date'] = parse_postgres_date($row['change_date']);
 			$changesets[] = new ChangeSet($row['id'], $row);
 		}
 		return $changesets;
@@ -370,7 +370,7 @@ class Zone extends Record {
 		$stmt->execute();
 		if($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
 			$row['author'] = $user_dir->get_user_by_id($row['author_id']);
-			$row['change_date'] = DateTime::createFromFormat('Y-m-d H:i:s.u', $row['change_date']);
+			$row['change_date'] = parse_postgres_date($row['change_date']);
 			return new ChangeSet($row['id'], $row);
 		}
 		throw new ChangeSetNotFound;
@@ -484,7 +484,7 @@ class Zone extends Record {
 		if($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
 			$update = new PendingUpdate($row['id'], $row);
 			$update->author = new User($row['author_id']);
-			$update->request_date = DateTime::createFromFormat('Y-m-d H:i:s.u', $row['request_date']);
+			$update->request_date = parse_postgres_date($row['request_date']);
 			$update->raw_data = stream_get_contents($row['raw_data']);
 			return $update;
 		}
@@ -503,7 +503,7 @@ class Zone extends Record {
 		while($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
 			$update = new PendingUpdate($row['id'], $row);
 			$update->author = new User($row['author_id']);
-			$update->request_date = DateTime::createFromFormat('Y-m-d H:i:s.u', $row['request_date']);
+			$update->request_date = parse_postgres_date($row['request_date']);
 			$update->raw_data = stream_get_contents($row['raw_data']);
 			$updates[] = $update;
 		}
@@ -535,10 +535,10 @@ class Zone extends Record {
 		$stmt->execute();
 		if($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
 			$row['requester'] = new User($row['requester_id']);
-			$row['request_date'] = DateTime::createFromFormat('Y-m-d H:i:s.u', $row['request_date']);
+			$row['request_date'] = parse_postgres_date($row['request_date']);
 			if(!is_null($row['confirmer_id'])) {
 				$row['confirmer'] = new User($row['confirmer_id']);
-				$row['confirm_date'] = DateTime::createFromFormat('Y-m-d H:i:s.u', $row['confirm_date']);
+				$row['confirm_date'] = parse_postgres_date($row['confirm_date']);
 			}
 			return $row;
 		}


### PR DESCRIPTION
I wasn't sure where a good place would be to add utility functions like this, so i added it inline in user.php and as a function in zone.php -- suggestions welcome!

(and yes: we actually hit this bug in production ;) )

**commit message**:

When SELECTing a date from the postgres database, and that date's
microsecond part is exactly zero, it will be omitted from the string
representation. This causes DateTime::createFromFormat to return false
instead of the date.

To reproduce this bug, create and then edit a zone (so a changeset entry
exists), then set its change_date like so:

    update changeset set change_date = '2021-11-23 10:37:38.000000' where id = 1;

note that when issuing a SELECT, the '.000000' will be automatically
stripped.

```
[23-Nov-2021 09:40:03 UTC] 1637660403: Error: Call to a member function format() on bool in /var/www/dns-ui/templates/zone.php:687
[23-Nov-2021 09:40:03 UTC] 1637660403: Stack trace:
[23-Nov-2021 09:40:03 UTC] 1637660403: #0 /var/www/dns-ui/pagesection.php(69): include()
[23-Nov-2021 09:40:03 UTC] 1637660403: #1 /var/www/dns-ui/pagesection.php(57): PageSection->generate()
[23-Nov-2021 09:40:03 UTC] 1637660403: #2 /var/www/dns-ui/templates/base.php(81): PageSection->get()
[23-Nov-2021 09:40:03 UTC] 1637660403: #3 /var/www/dns-ui/pagesection.php(69): include('/var/www/dns-ui...')
[23-Nov-2021 09:40:03 UTC] 1637660403: #4 /var/www/dns-ui/views/zone.php(321): PageSection->generate()
[23-Nov-2021 09:40:03 UTC] 1637660403: #5 /var/www/dns-ui/requesthandler.php(62): require('/var/www/dns-ui...')
[23-Nov-2021 09:40:03 UTC] 1637660403: #6 /var/www/dns-ui/public_html/init.php(18): require('/var/www/dns-ui...')
[23-Nov-2021 09:40:03 UTC] 1637660403: #7 {main}
```