### PR TITLE
Zone Changelog: filter and paginate

### DIFF
--- a/public_html/style.css
+++ b/public_html/style.css
@@ -172,6 +172,10 @@ table.changelog table td.content {
 	word-break: break-all;
 }
 
+#changelog-search {
+	display: inline;
+}
+
 #changelog-expand-all, #changelog-collapse-all {
 	float: right;
 }

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -19,6 +19,8 @@ $zone = $this->get('zone');
 $rrsets = $this->get('rrsets');
 $pending = $this->get('pending');
 $changesets = $this->get('changesets');
+$changeset_filters = $this->get('changeset_filters');
+$changeset_pagecount = $this->get('changeset_pagecount');
 $access = $this->get('access');
 $accounts = $this->get('accounts');
 $cryptokeys = $this->get('cryptokeys');
@@ -664,7 +666,22 @@ global $output_formatter;
 	</div>
 	<?php } ?>
 	<div role="tabpanel" class="tab-pane" id="changelog">
+		<?php
+		$changeset_page = $changeset_filters['page'];
+		$start_date = isset($changeset_filters['start_date']) ? $changeset_filters['start_date']->format("Y-m-d") : "";
+		$end_date = isset($changeset_filters['end_date']) ? $changeset_filters['end_date']->format("Y-m-d") : "";
+		$comment_query = isset($changeset_filters['comment']) ? $changeset_filters['comment'] : "";
+		function pagination($page) {
+			return out("?" . http_build_query(array_merge($_GET, ['page'=>$page])));
+		}
+		?>
 		<h2 class="sr-only">Changelog</h2>
+		<form class="form-inline" id="changelog-search" action="" method="GET">
+			<input placeholder="search comments" name="changeset_comment" value="<?php out($comment_query)?>" class="form-control">
+			<label>from: <input type="date" name="changeset_start" value="<?php out($start_date)?>" class="form-control"></label>
+			<label>to: <input type="date" name="changeset_end" value="<?php out($end_date)?>" class="form-control"></label>
+			<input type="submit" value="Search" class="btn btn-primary">
+		</form>
 		<button class="btn btn-default" id="changelog-expand-all">expand all</button>
 		<button class="btn btn-default" id="changelog-collapse-all">collapse all</button>
 		<?php if(count($changesets) == 0) { ?>
@@ -694,6 +711,33 @@ global $output_formatter;
 				<?php } ?>
 			</tbody>
 		</table>
+		<ul class="pagination">
+			<?php if ($changeset_page > 1) { ?>
+				<li><a href="<?php pagination(1)?>">First</a></li>
+				<li><a href="<?php pagination($changeset_page-1)?>">Previous</a></li>
+			<?php } else { ?>
+				<li class="disabled"><a>First</a></li>
+				<li class="disabled"><a>Previous</a></li>
+			<?php } ?>
+			<!-- 5 pages before and after the current page (if available). '...' to suggest that there are more pages -->
+			<?php if ($changeset_page-5 > 1) { ?>
+				<li class="disabled"><a>&hellip;</a></li>
+			<?php } ?>
+			<?php for($i = max($changeset_page-5, 1); $i <= min($changeset_page+5, $changeset_pagecount); $i++) { ?>
+				<li class="<?php if($i == $changeset_page) { out('active'); }?>"><a href="<?php pagination($i)?>"><?php out($i)?></a></li>
+			<?php } ?>
+			<?php if ($changeset_page+5 < $changeset_pagecount) { ?>
+				<li class="disabled"><a>&hellip;</a></li>
+			<?php } ?>
+			<?php if ($changeset_page < $changeset_pagecount) { ?>
+				<li><a href="<?php pagination($changeset_page+1)?>">Next</a></li>
+				<li><a href="<?php pagination($changeset_pagecount)?>">Last</a></li>
+			</li>
+			<?php } else { ?>
+				<li class="disabled"><a>Next</a></li>
+				<li class="disabled"><a>Last</a></li>
+			<?php } ?>
+		</ul>
 	</div>
 	<div role="tabpanel" class="tab-pane" id="access">
 		<h2 class="sr-only">User access</h2>

--- a/views/api.php
+++ b/views/api.php
@@ -156,7 +156,7 @@ class API {
 		global $zone_dir, $active_user;
 		$zone = $zone_dir->get_zone_by_name($zone_name);
 		if(!$active_user->admin && !$active_user->access_to($zone)) throw new AccessDenied;
-		$changesets = $zone->list_changesets();
+		list($changeset_pagecount, $changesets) = $zone->list_changesets();
 		$list = array();
 		foreach($changesets as $changeset) {
 			$item = new StdClass;

--- a/views/zone.php
+++ b/views/zone.php
@@ -53,7 +53,41 @@ try {
 	}
 }
 $pending = $zone->list_pending_updates();
-$changesets = $zone->list_changesets();
+
+$changeset_filters = array();
+if (isset($_GET['changeset_comment']) and !empty($_GET['changeset_comment'])) {
+	$changeset_filters['comment'] = $_GET['changeset_comment'];
+}
+if (isset($_GET['changeset_start']) and !empty($_GET['changeset_start'])) {
+	$start_date = DateTime::createFromFormat("!Y-m-d", $_GET['changeset_start']);
+	if ($start_date) {
+		$changeset_filters['start_date'] = $start_date;
+	} else {
+		// warn the user that their date is invalid
+		$alert = new UserAlert;
+		$alert->content = 'Invalid date supplied; ignoring.';
+		$alert->class = 'warning';
+		$active_user->add_alert($alert);
+	}
+}
+if (isset($_GET['changeset_end']) and !empty($_GET['changeset_end'])) {
+	$end_date = DateTime::createFromFormat("!Y-m-d", $_GET['changeset_end']);
+	if ($end_date) {
+		$changeset_filters['end_date'] = $end_date;
+	} else {
+		// warn the user that their date is invalid
+		$alert = new UserAlert;
+		$alert->content = 'Invalid date supplied; ignoring.';
+		$alert->class = 'warning';
+		$active_user->add_alert($alert);
+	}
+}
+$changeset_filters['page'] = 1;
+if (isset($_GET['page']) and !empty($_GET['page'])) {
+	$changeset_filters['page'] = $changeset_filters['page'] = max(1, intval($_GET['page']));
+}
+list($changeset_pagecount, $changesets) = $zone->list_changesets($changeset_filters);
+
 $access = $zone->list_access();
 $cryptokeys = $zone->get_cryptokeys();
 $accounts = $zone_dir->list_accounts();
@@ -295,6 +329,8 @@ if(!isset($content)) {
 	$content->set('rrsets', $rrsets);
 	$content->set('pending', $pending);
 	$content->set('changesets', $changesets);
+	$content->set('changeset_filters', $changeset_filters);
+	$content->set('changeset_pagecount', $changeset_pagecount);
 	$content->set('access', $access);
 	$content->set('accounts', $accounts);
 	$content->set('cryptokeys', $cryptokeys);


### PR DESCRIPTION
Most of what I'd consider controversial takes place in `models/zone.php:list_changesets()`:
- It now takes an optional parameter for a list of filters (search comment, date range, pagination)
- It now returns two values (changes as before, plus total number of pages) => this is a breaking (internal) change, so all usages were updated.
- Items per page is for now hardcoded in there to 200. I'm open to improve this (config.ini knob?) if this is a problem.
- The SQL statement to select changelog entries is now relatively complex. To allow for the optional filter parameters, they have to be passed twice. This is a bit ugly, but I don't see a nicer alternative (assembling the SQL query as a string with if/else seems even worse).

I'm also a bit unhappy with the amount of `<?php...?>` blocks for pagination in `templates/zone.php` but there's just a lot of cases to check.


### commit message:


Implements:
- filter by comment (default all)
- filter by date range (default all)
- paginate results (200 items per page)

Filtering by author, while possible, is not implemented in this patch,
since we don't care about it. Note that the changelog displayed on a
user's profile is not touched; it continues to be unpaginated and
unfilterable for the same reason.

fixes #179