### PR TITLE
fix php81 (ErrorException: unserialize(): Passing null to parameter #…

### DIFF
--- a/views/api.php
+++ b/views/api.php
@@ -191,8 +191,14 @@ class API {
 		foreach($changeset->list_changes() as $change) {
 			$c_data = new StdClass;
 			$states = array();
-			$states['before'] = unserialize($change->before);
-			$states['after'] = unserialize($change->after);
+			$check_before = $change->before;
+			$check_after = $change->after;
+			if(isset($check_before)) {
+				$states['before'] = unserialize($change->before);
+			}
+			if(isset($check_after)) {
+				$states['after'] = unserialize($change->after);
+			}
 			foreach($states as $state => $rrset) {
 				if($rrset) {
 					$c_data->{$state} = new StdClass;

--- a/views/api.php
+++ b/views/api.php
@@ -191,12 +191,10 @@ class API {
 		foreach($changeset->list_changes() as $change) {
 			$c_data = new StdClass;
 			$states = array();
-			$check_before = $change->before;
-			$check_after = $change->after;
-			if(isset($check_before)) {
+			if(!is_null($change->before)) {
 				$states['before'] = unserialize($change->before);
 			}
-			if(isset($check_after)) {
+			if(!is_null($change->after)) {
 				$states['after'] = unserialize($change->after);
 			}
 			foreach($states as $state => $rrset) {


### PR DESCRIPTION
It happens when change->before or change->after is null and php8.1 is used.
 

Fix error in PHP8.1

[29-Aug-2022 09:27:38 UTC] 1661765258: ErrorException: unserialize(): Passing null to parameter #1 ($data) of type string is deprecated in /usr/local/share/dns-ui/views/api.p-hp:324                                                                                                                                                                        
[29-Aug-2022 09:27:38 UTC] 1661765258: Stack trace:                                                                                                                           
[29-Aug-2022 09:27:38 UTC] 1661765258: #0 [internal function]: exception_error_handler()                                                                                      
[29-Aug-2022 09:27:38 UTC] 1661765258: #1 /usr/local/share/dns-ui/views/api.php(324): unserialize()                                                                           
[29-Aug-2022 09:27:38 UTC] 1661765258: #2 /usr/local/share/dns-ui/views/api.php(115): API->show_zone_change()                                                                 
[29-Aug-2022 09:27:38 UTC] 1661765258: #3 /usr/local/share/dns-ui/views/api.php(305): API->options()
[29-Aug-2022 09:27:38 UTC] 1661765258: #4 /usr/local/share/dns-ui/views/api.php(39): API->zone_change()
[29-Aug-2022 09:27:38 UTC] 1661765258: #5 /usr/local/share/dns-ui/requesthandler.php(62): require('/usr/local/shar...')
[29-Aug-2022 09:27:38 UTC] 1661765258: #6 /usr/local/share/dns-ui/public_html/init.php(18): require('/usr/local/shar...')
[29-Aug-2022 09:27:38 UTC] 1661765258: #7 {main}  

Signed-off-by: Sergey V. Osipov <sipopo@yandex.ru>