### PR TITLE
Crashed if you have empty comment in changes

### DIFF
--- a/core.php
+++ b/core.php
@@ -157,7 +157,7 @@ function outurl($url) {
  * @return string HTML-escaped string
  */
 function hesc($string) {
-	return htmlspecialchars($string);
+	return htmlspecialchars($string ?? '');
 }
 
 function english_list($array) {


### PR DESCRIPTION
If somehow you get an empty comment in changelog you can't enter in that zone.

PHP 8.1

Error: 
[17-Feb-2023 11:32:01 UTC] 1676633521: ErrorException: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /usr/local/share/dns-ui/core.php:160
[17-Feb-2023 11:32:01 UTC] 1676633521: Stack trace:
[17-Feb-2023 11:32:01 UTC] 1676633521: #0 [internal function]: exception_error_handler()
[17-Feb-2023 11:32:01 UTC] 1676633521: #1 /usr/local/share/dns-ui/core.php(160): htmlspecialchars()
[17-Feb-2023 11:32:01 UTC] 1676633521: #2 /usr/local/share/dns-ui/core.php(489): hesc()
[17-Feb-2023 11:32:01 UTC] 1676633521: #3 /usr/local/share/dns-ui/templates/zone.php(724): OutputFormatter->changeset_comment_format()
[17-Feb-2023 11:32:01 UTC] 1676633521: #4 /usr/local/share/dns-ui/pagesection.php(69): include('/usr/local/shar...')
[17-Feb-2023 11:32:01 UTC] 1676633521: #5 /usr/local/share/dns-ui/pagesection.php(57): PageSection->generate()
[17-Feb-2023 11:32:01 UTC] 1676633521: #6 /usr/local/share/dns-ui/templates/base.php(81): PageSection->get()
[17-Feb-2023 11:32:01 UTC] 1676633521: #7 /usr/local/share/dns-ui/pagesection.php(69): include('/usr/local/shar...')
[17-Feb-2023 11:32:01 UTC] 1676633521: #8 /usr/local/share/dns-ui/views/zone.php(359): PageSection->generate()
[17-Feb-2023 11:32:01 UTC] 1676633521: #9 /usr/local/share/dns-ui/requesthandler.php(62): require('/usr/local/shar...')
[17-Feb-2023 11:32:01 UTC] 1676633521: #10 /usr/local/share/dns-ui/public_html/init.php(18): require('/usr/local/shar...')
[17-Feb-2023 11:32:01 UTC] 1676633521: #11 {main}

