### PR TITLE
read authentication from $REMOTE_USER

### DIFF
--- a/requesthandler.php
+++ b/requesthandler.php
@@ -22,6 +22,8 @@ set_exception_handler('exception_handler');
 
 if(isset($_SERVER['PHP_AUTH_USER'])) {
 	$active_user = $user_dir->get_user_by_uid($_SERVER['PHP_AUTH_USER']);
+} elseif(isset($_SERVER['REMOTE_USER'])) {
+	$active_user = $user_dir->get_user_by_uid($_SERVER['REMOTE_USER']);
 } else {
 	throw new Exception("Not logged in.");
 }


### PR DESCRIPTION
This change allows other authentication methods than HTTP Basic Auth with Apache. httpd puts user information (e.g when using SSLVerifyClient and SSLUserName) into $REMOTE_USER, which is not picked up by PHP's basic auth variables.

This allows login with client certificates, using a config like this:

```
        SSLVerifyClient      optional
        SSLVerifyDepth       3
        SSLOptions           +StdEnvVars +ExportCertData +OptRenegotiate
        SSLUserName          SSL_CLIENT_S_DN_CN

        <Directory /var/www/html/dnsui/public_html>

                SSLRequireSSL
                Require expr %{SSL_CLIENT_S_DN_CN} == "myCertCommonName"
                Require all denied

                # fallback to basic auth if no client cert present:
                AuthType Basic
                AuthName "DNS UI"
                AuthBasicProvider file
                AuthUserFile "/var/www/html/dnsui/config/htpass"
                Require user apiUser1 apiUser2

        </Directory>
```


I believe that at least for apache, only reading $REMOTE_USER would be enough, but I'm keeping PHP_AUTH_USER for safety in this pullrequest. 