### PR TITLE
allow creating untyped public properties dynamically

### DIFF
--- a/model/zonedirectory.php
+++ b/model/zonedirectory.php
@@ -18,6 +18,7 @@
 /**
 * Class for reading/writing to the list of Zone objects in the database.
 */
+#[AllowDynamicProperties]
 class ZoneDirectory extends DBDirectory {
 	/**
 	* PowerDNS communication object


### PR DESCRIPTION
avoid error
```
PHP Fatal error:  Uncaught ErrorException: Creation of dynamic property ZoneDirectory::$cache_uid is deprecated in /srv/opera-dnsui/model/zonedirectory.php:35\nStack trace:\n#0 /srv/opera-dnsui/model/zonedirectory.php(35): exception_error_handler()\n#1 /srv/opera-dnsui/core.php(84): ZoneDirectory->__construct()\n#2 /srv/opera-dnsui/core.php(56): setup_database()\n#3 /srv/opera-dnsui/requesthandler.php(19): require('...')\n#4 /srv/opera-dnsui/public_html/init.php(18): require('...')\n#5 {main}\n  thrown in /srv/opera-dnsui/model/zonedirectory.php on line 35
```
closes #201