### PR TITLE
removed deprecated set-ptr and autocreate_reverse_records

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -104,10 +104,6 @@ dnssec = 0
 ; Allow enabling/disabling DNSSEC through the UI
 dnssec_edit = 1
 
-; If enabled (the default), matching PTR records will be automatically created
-; when new A or AAAA records are added.
-autocreate_reverse_records = 1
-
 ; Space-separated lists
 local_zone_suffixes = "localdomain"
 local_ipv4_ranges = "10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 127.0.0.0/8"

--- a/model/zone.php
+++ b/model/zone.php
@@ -783,12 +783,6 @@ class Zone extends Record {
 		}
 		if(($update->type == 'SOA' || $update->type == 'NS') && !$active_user->admin) return;
 
-		if(isset($config['dns']['autocreate_reverse_records'])) {
-			$autocreate_ptr = (bool)$config['dns']['autocreate_reverse_records'];
-		} else {
-			$autocreate_ptr = true; # enabled by default
-		}
-
 		switch($update->action) {
 		case 'add':
 			if(!isset($update->records) || !is_array($update->records)) throw new BadData('Malformed action');
@@ -807,11 +801,6 @@ class Zone extends Record {
 				$rr = new ResourceRecord;
 				$rr->content = $record->content;
 				$rr->disabled = ($record->enabled === 'No' || $record->enabled === false);
-				if(!$autocreate_ptr || $rr->disabled) {
-					$rr->{'set-ptr'} = false;
-				} else {
-					$rr->{'set-ptr'} = $zone_dir->check_reverse_record_zone($rrset->name, $rrset->type, $rr->content, $revs_missing, $revs_updated);
-				}
 				$rrset->add_resource_record($rr);
 			}
 			if(isset($update->comment)) {
@@ -846,11 +835,6 @@ class Zone extends Record {
 				$rr = new ResourceRecord;
 				$rr->content = $record->content;
 				$rr->disabled = ($record->enabled === 'No' || $record->enabled === false);
-				if(!$autocreate_ptr || $rr->disabled) {
-					$rr->{'set-ptr'} = false;
-				} else {
-					$rr->{'set-ptr'} = $zone_dir->check_reverse_record_zone($rrset->name, $rrset->type, $rr->content, $revs_missing, $revs_updated);
-				}
 				$rrset->add_resource_record($rr);
 			}
 			if(isset($update->comment) && $update->comment != $rrset->merge_comment_text()) {


### PR DESCRIPTION
as `set-ptr` (https://github.com/PowerDNS/pdns/pull/7797) has been removed, remove all related settings