### PR TITLE
don't repeatedly update URL fragment with 'expand all' button

### DIFF
--- a/public_html/extra.js
+++ b/public_html/extra.js
@@ -956,7 +956,9 @@ $(function() {
 		var changeset = tr.data('changeset');
 
 		var hash = '#changelog#' + changeset;
-		if(history) {
+		if(display !== undefined) {
+			// don't do anything for #changelog-expand-all / #changelog-collapse-all
+		} else if(history) {
 			history.replaceState(null, null, hash);
 		} else {
 			window.location.hash = hash;


### PR DESCRIPTION
in firefox, doing this more than 200 times causes the following error, and expansion stops after this many elements:

> Too many calls to Location or History APIs within a short timeframe.
> Uncaught DOMException: The operation is insecure.

this limit was introduced in https://bugzilla.mozilla.org/show_bug.cgi?id=1314912

chrom{ium,e} doesn't implement this mitigation, but on large zones I managed to hang and subsequently crash the browser, instead.