### PR TITLE
Add Active Directory LDAP_MATCHING_RULE_IN_CHAIN example

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -81,6 +81,10 @@ user_email = mail
 ;  group_member = member
 ;  group_member_value = dn
 ;
+; Active Directory LDAP_MATCHING_RULE_IN_CHAIN (nested groups)
+;  group_member = "member:1.2.840.113556.1.4.1941:"
+;  group_member_value = "dn"
+;
 ; Attribute of group where members are stored
 group_member = memberUid
 ; User attribute to compare with


### PR DESCRIPTION
Example to achieve nested or recursive group lookups with Active Directory