### PR TITLE
Add optional logout menu entry.

### DIFF
--- a/config/config-sample.ini
+++ b/config/config-sample.ini
@@ -7,6 +7,10 @@ logo = /logo-header-opera.png
 ; header and footer may contain HTML. Literal & " < and > should be escaped as &amp; &quot; &lt; $gt;
 header = 'DNS management'
 footer = 'Developed by <a href="https://www.opera.com/">Opera Software</a>.'
+; Enable this option to add a logout menu link to the specified URL
+;logout_url = '/logout'
+; Enable this option to set the logout menu link text
+;logout_text = 'Logout'
 ; Enable this option if you want system and zone admins to be forced to request changes just like the operators.
 ;force_change_review = 1
 ; Enable this option if you want all users to be forced to enter a comment for every change made.

--- a/templates/base.php
+++ b/templates/base.php
@@ -67,6 +67,7 @@ header("Content-Security-Policy: default-src 'self'");
 				<li<?php if($contents == $this->get('relative_request_url')) out(' class="active"', ESC_NONE); ?>><a href="<?php outurl($contents)?>"><?php out($name)?></a></li>
 				<?php } ?>
 				<?php } ?>
+				<?php if(!empty($web_config['logout_url'])) { ?><li><a href="<?php outurl($web_config['logout_url']) ?>"><?php if (!empty($web_config['logout_text'])) out($web_config['logout_text']); else { ?>Logout<?php } ?></a></li><?php } ?>
 			</ul>
 		</div>
 	</div>


### PR DESCRIPTION
This pull request add and optional logout menu entry, configured by two configuration variables in the `[web]` section:
- `logout_url`: the target URL of the logout menu entry
- `logout_text`: the displayed text in the logout menu entry

Please note that the link will not perform any logout by itself. I is the responsibility of the system administrator to make something useful out of the link.

For instance, when running `dns-ui` behind [Nginx](https://nginx.org/en/) as a reverse proxy (using the [`auth_request` module](https://github.com/operasoftware/dns-ui/wiki/Example-configuration:-nginx#example-using-nginx--auth_request-module-to-authenticate-with-oauth2_proxy)) , with [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) and [Keycloak OIDC](https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/keycloak_oidc/) as authentication client, the following snippets can be useful:

In Nginx config:
```nginx
location /logout {
	return 302 http://<url_of_your_openauth2_proxy_instance>/sign_out?rd=<url_of_page_to_display_after_logout>;
}
```


In oauth2-proxy config:
```ini
backend_logout_url="http://<url_of_your_keycloak_instance>/realms/<realm_name>/protocol/openid-connect/logout?id_token_hint={id_token}"
```
