### PR TITLE
Add zone superadministrator role with enhanced NS/CAA record permissions

### DIFF
--- a/migrations/007.php
+++ b/migrations/007.php
@@ -1,4 +1,4 @@
 <?php
-$migration_name = 'Add superadministrator role';
+$migration_name = 'Add zone super administrator role';
 
-$this->database->exec("ALTER TYPE access_level ADD VALUE IF NOT EXISTS 'superadministrator'");
+$this->database->exec("ALTER TYPE access_level ADD VALUE IF NOT EXISTS 'zone-super-administrator'");

--- a/migrations/007.php
+++ b/migrations/007.php
@@ -1,0 +1,4 @@
+<?php
+$migration_name = 'Add superadministrator role';
+
+$this->database->exec("ALTER TYPE access_level ADD VALUE IF NOT EXISTS 'superadministrator'");

--- a/model/migrationdirectory.php
+++ b/model/migrationdirectory.php
@@ -22,7 +22,7 @@ class MigrationDirectory extends DBDirectory {
 	/**
 	* Increment this constant to activate a new migration from the migrations directory
 	*/
-	const LAST_MIGRATION = 6;
+	const LAST_MIGRATION = 7;
 
 	public function __construct() {
 		parent::__construct();

--- a/model/user.php
+++ b/model/user.php
@@ -196,6 +196,15 @@ class User extends Record {
 	}
 
 	/**
+	* Check if this user is a zone superadministrator for the specified zone.
+	* @param Zone $zone to check for superadmin access
+	* @return bool true if user is zone superadministrator
+	*/
+	public function is_zone_superadmin(Zone $zone) {
+		return $this->access_to($zone) === 'superadministrator';
+	}
+
+	/**
 	* List all zones that this user is an administrator of
 	* @param array $include list of extra data to include in response
 	* @return array of Zone objects

--- a/model/user.php
+++ b/model/user.php
@@ -196,12 +196,12 @@ class User extends Record {
 	}
 
 	/**
-	* Check if this user is a zone superadministrator for the specified zone.
-	* @param Zone $zone to check for superadmin access
-	* @return bool true if user is zone superadministrator
+	* Check if this user is a zone super administrator for the specified zone.
+	* @param Zone $zone to check for super administrator access
+	* @return bool true if user is zone super administrator
 	*/
-	public function is_zone_superadmin(Zone $zone) {
-		return $this->access_to($zone) === 'superadministrator';
+	public function is_zone_super_administrator(Zone $zone) {
+		return $this->access_to($zone) === 'zone-super-administrator';
 	}
 
 	/**

--- a/model/zone.php
+++ b/model/zone.php
@@ -781,7 +781,7 @@ class Zone extends Record {
 			$update->oldname = $update->name;
 			$update->oldtype = $update->type;
 		}
-		if(($update->type == 'SOA' || $update->type == 'NS') && !$active_user->admin) return;
+		if(($update->type == 'SOA' || $update->type == 'NS') && !($active_user->admin || $active_user->is_zone_superadmin($this))) return;
 
 		if(isset($config['dns']['autocreate_reverse_records'])) {
 			$autocreate_ptr = (bool)$config['dns']['autocreate_reverse_records'];

--- a/model/zone.php
+++ b/model/zone.php
@@ -501,6 +501,22 @@ class Zone extends Record {
 	*/
 	public function add_pending_update($update) {
 		global $active_user;
+		
+		// Security check: Prevent creation of pending updates for restricted record types
+		// Only global admins and zone super administrators can request changes to SOA, NS, and CAA records
+		$update_data = json_decode($update);
+		if($update_data && isset($update_data->actions)) {
+			foreach($update_data->actions as $action) {
+				if(($action->type == 'SOA' || $action->type == 'NS' || $action->type == 'CAA') ||
+				   (isset($action->oldtype) && ($action->oldtype == 'SOA' || $action->oldtype == 'NS' || $action->oldtype == 'CAA'))) {
+					if(!($active_user->admin || $active_user->is_zone_super_administrator($this))) {
+						throw new RuntimeException('You are not authorized to request changes to SOA, NS, or CAA records.');
+					}
+					break;
+				}
+			}
+		}
+		
 		$stmt = $this->database->prepare('INSERT INTO pending_update (zone_id, author_id, request_date, raw_data) VALUES (?, ?, NOW(), ?)');
 		$stmt->bindParam(1, $this->id, PDO::PARAM_INT);
 		$stmt->bindParam(2, $active_user->id, PDO::PARAM_INT);
@@ -781,7 +797,11 @@ class Zone extends Record {
 			$update->oldname = $update->name;
 			$update->oldtype = $update->type;
 		}
-		if(($update->type == 'SOA' || $update->type == 'NS' || $update->type == 'CAA') && !($active_user->admin || $active_user->is_zone_super_administrator($this))) return;
+		// Security check: Only global admins and zone super administrators can edit SOA, NS and CAA records.
+		// We must check BOTH the new type and the original type to prevent privilege-escalation via rename/delete.
+		if((($update->type == 'SOA' || $update->type == 'NS' || $update->type == 'CAA') ||
+		    (isset($update->oldtype) && ($update->oldtype == 'SOA' || $update->oldtype == 'NS' || $update->oldtype == 'CAA')))
+		   && !($active_user->admin || $active_user->is_zone_super_administrator($this))) return;
 
 		if(isset($config['dns']['autocreate_reverse_records'])) {
 			$autocreate_ptr = (bool)$config['dns']['autocreate_reverse_records'];

--- a/model/zone.php
+++ b/model/zone.php
@@ -781,7 +781,7 @@ class Zone extends Record {
 			$update->oldname = $update->name;
 			$update->oldtype = $update->type;
 		}
-		if(($update->type == 'SOA' || $update->type == 'NS' || $update->type == 'CAA') && !($active_user->admin || $active_user->is_zone_superadmin($this))) return;
+		if(($update->type == 'SOA' || $update->type == 'NS' || $update->type == 'CAA') && !($active_user->admin || $active_user->is_zone_super_administrator($this))) return;
 
 		if(isset($config['dns']['autocreate_reverse_records'])) {
 			$autocreate_ptr = (bool)$config['dns']['autocreate_reverse_records'];

--- a/model/zone.php
+++ b/model/zone.php
@@ -781,7 +781,7 @@ class Zone extends Record {
 			$update->oldname = $update->name;
 			$update->oldtype = $update->type;
 		}
-		if(($update->type == 'SOA' || $update->type == 'NS') && !($active_user->admin || $active_user->is_zone_superadmin($this))) return;
+		if(($update->type == 'SOA' || $update->type == 'NS' || $update->type == 'CAA') && !($active_user->admin || $active_user->is_zone_superadmin($this))) return;
 
 		if(isset($config['dns']['autocreate_reverse_records'])) {
 			$autocreate_ptr = (bool)$config['dns']['autocreate_reverse_records'];

--- a/public_html/extra.js
+++ b/public_html/extra.js
@@ -122,7 +122,7 @@ $(function() {
 			var tr = element.closest('tr');
 			var recordType = tr.data('type');
 			var userAdmin = form.data('user-admin') == 1;
-			var userSuperadmin = form.data('user-superadmin') == 1;
+			var userSuperadmin = form.data('user-super-zone-admin') == 1;
 			
 			// NS and CAA records can only be edited by admins or super zone admins
 			if((recordType == 'NS' || recordType == 'CAA') && !(userAdmin || userSuperadmin)) {

--- a/public_html/extra.js
+++ b/public_html/extra.js
@@ -77,12 +77,12 @@ $(function() {
 		$('#new_ttl').data('default-value', $('#new_ttl').val());
 		$('option:first-of-type', typeselect).remove();
 		$('button.delete-rr', form).on('click', function() { delete_rr($(this)); });
-		$('td.name', form).on('click', function() { make_editable($(this), 'name'); });
-		$('td.type', form).on('click', function() { make_editable($(this), 'type'); });
-		$('td.ttl', form).on('click', function() { make_editable($(this), 'ttl'); });
-		$('td.content', form).on('click', function() { make_editable($(this), 'content'); });
-		$('td.enabled', form).on('click', function() { make_editable($(this)); });
-		$('td.comment', form).on('click', function() { make_editable($(this), 'comment'); });
+		$('td.name', form).on('click', function() { if(can_edit_record($(this))) make_editable($(this), 'name'); });
+		$('td.type', form).on('click', function() { if(can_edit_record($(this))) make_editable($(this), 'type'); });
+		$('td.ttl', form).on('click', function() { if(can_edit_record($(this))) make_editable($(this), 'ttl'); });
+		$('td.content', form).on('click', function() { if(can_edit_record($(this))) make_editable($(this), 'content'); });
+		$('td.enabled', form).on('click', function() { if(can_edit_record($(this))) make_editable($(this)); });
+		$('td.comment', form).on('click', function() { if(can_edit_record($(this))) make_editable($(this), 'comment'); });
 		$('tbody tr', form).each(function() { max_rrsetnum = Math.max(max_rrsetnum, parseInt($(this).data('rrsetnum'), 10)); });
 		$('#new_name').on('keyup', function(event) { validate_new(); if(event.which == 13) add_new(); });
 		$('#new_name').on('change', function() { validate_new(); });
@@ -115,6 +115,20 @@ $(function() {
 				tr.data('delete', true);
 			}
 			update_changed(button);
+		}
+
+		// Check if user can edit this record
+		function can_edit_record(element) {
+			var tr = element.closest('tr');
+			var recordType = tr.data('type');
+			var userAdmin = form.data('user-admin') == 1;
+			var userSuperadmin = form.data('user-superadmin') == 1;
+			
+			// NS and CAA records can only be edited by admins or super zone admins
+			if((recordType == 'NS' || recordType == 'CAA') && !(userAdmin || userSuperadmin)) {
+				return false;
+			}
+			return true;
 		}
 
 		// Make the selected row editable and focus the chosen cell

--- a/public_html/style.css
+++ b/public_html/style.css
@@ -244,3 +244,14 @@ div.stickyHeader th {
 .javascript .nu0 {color: #CC0000;}
 .javascript .me1 {color: #660066;}
 .javascript span.xtra { display:block; }
+
+/* Read-only records styling */
+table.rrsets tr.read-only {
+	opacity: 0.7;
+}
+table.rrsets tr.read-only td {
+	cursor: not-allowed;
+}
+table.rrsets tr.read-only td:hover {
+	background-color: #f5f5f5;
+}

--- a/public_html/style.css
+++ b/public_html/style.css
@@ -255,3 +255,11 @@ table.rrsets tr.read-only td {
 table.rrsets tr.read-only td:hover {
 	background-color: #f5f5f5;
 }
+
+/* User info in navbar */
+.navbar-text .glyphicon-user {
+	margin-right: 5px;
+}
+.navbar-text {
+	color: #777;
+}

--- a/templates/base.php
+++ b/templates/base.php
@@ -68,6 +68,14 @@ header("Content-Security-Policy: default-src 'self'");
 				<?php } ?>
 				<?php } ?>
 			</ul>
+			<?php if(is_object($this->get('active_user'))) { ?>
+			<ul class="nav navbar-nav navbar-right">
+				<li class="navbar-text">
+					<span class="glyphicon glyphicon-user"></span>
+					<?php out($this->get('active_user')->name)?> (<?php out($this->get('active_user')->uid)?>)
+				</li>
+			</ul>
+			<?php } ?>
 		</div>
 	</div>
 </div>

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -66,7 +66,7 @@ global $output_formatter;
 <div class="tab-content">
 	<div role="tabpanel" class="tab-pane active" id="records">
 		<h2 class="sr-only">Resource records</h2>
-		<form method="post" action="<?php outurl('/zones/'.urlencode(DNSZoneName::unqualify($zone->name)))?>" class="zoneedit" data-zone="<?php out($zone->name)?>" data-local-zone="<?php out($local_zone ? 1 : 0)?>" data-local-ipv4-ranges="<?php out($local_ipv4_ranges)?>" data-local-ipv6-ranges="<?php out($local_ipv6_ranges)?>" data-user-admin="<?php out($active_user->admin ? 1 : 0)?>" data-user-super-zone-admin="<?php out($active_user->is_zone_superadmin($zone) ? 1 : 0)?>">
+		<form method="post" action="<?php outurl('/zones/'.urlencode(DNSZoneName::unqualify($zone->name)))?>" class="zoneedit" data-zone="<?php out($zone->name)?>" data-local-zone="<?php out($local_zone ? 1 : 0)?>" data-local-ipv4-ranges="<?php out($local_ipv4_ranges)?>" data-local-ipv6-ranges="<?php out($local_ipv6_ranges)?>" data-user-admin="<?php out($active_user->admin ? 1 : 0)?>" data-user-super-zone-admin="<?php out($active_user->is_zone_super_administrator($zone) ? 1 : 0)?>">
 			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 			<nav></nav>
 			<table class="table table-bordered table-condensed table-hover stickyHeader rrsets">
@@ -99,7 +99,7 @@ global $output_formatter;
 						if($alldisabled) $rowclasses[] = 'rrset-disable';
 						if($rrsetnum > $maxperpage) $rowclasses[] = 'hidden';
 						?>
-					<tr data-name="<?php out(punycode_to_utf8($name))?>" data-type="<?php out($rrset->type)?>" data-rrsetnum="<?php out($rrsetnum)?>" class="<?php out(implode(' ', $rowclasses))?><?php if(($rrset->type == 'NS' || $rrset->type == 'CAA') && !($active_user->admin || $active_user->is_zone_superadmin($zone))) echo ' read-only'; ?>">
+					<tr data-name="<?php out(punycode_to_utf8($name))?>" data-type="<?php out($rrset->type)?>" data-rrsetnum="<?php out($rrsetnum)?>" class="<?php out(implode(' ', $rowclasses))?><?php if(($rrset->type == 'NS' || $rrset->type == 'CAA') && !($active_user->admin || $active_user->is_zone_super_administrator($zone))) echo ' read-only'; ?>">
 						<td class="name" rowspan="<?php out(count($rrs))?>"><?php out(punycode_to_utf8($name))?></td>
 						<td class="type" rowspan="<?php out(count($rrs))?>"><?php out($rrset->type)?></td>
 						<td class="ttl" rowspan="<?php out(count($rrs))?>"><?php out(DNSTime::abbreviate($rrset->ttl))?></td>
@@ -139,7 +139,7 @@ global $output_formatter;
 						<td class="enabled"><?php out($rr->disabled ? 'No' : 'Yes')?></td>
 						<td class="actions">
 							<?php if($rrset->type == 'NS' || $rrset->type == 'CAA') { ?>
-								<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+								<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 									<button type="button" class="btn btn-default btn-xs delete-rr"><span class="glyphicon glyphicon-trash"></span> Delete</button>
 								<?php } else { ?>
 									<span class="text-muted">Read-only</span>
@@ -171,7 +171,7 @@ global $output_formatter;
 								<?php if($reverse) { ?>
 								<option value="CNAME" data-content-pattern="\S+">CNAME</option>
 								<option value="DS" data-content-pattern="[0-9]+\s+[0-9]+\s+[0-9]+\s+[a-zA-Z0-9]+">DS</option>
-								<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+								<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 								<option value="NS" data-content-pattern="\S*">NS</option>
 								<?php } ?>
 								<option value="PTR" data-content-pattern="\S+">PTR</option>
@@ -179,7 +179,7 @@ global $output_formatter;
 								<option value="A" data-content-pattern="((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])">A</option>
 								<option value="AAAA" data-content-pattern="(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))">AAAA</option>
 								<option value="ALIAS" data-content-pattern="\S+">ALIAS</option>
-								<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+								<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 								<option value="CAA" data-content-pattern="[0-9]+\s+\S+\s+\S+">CAA</option>
 								<?php } ?>
 								<option value="CNAME" data-content-pattern="\S+">CNAME</option>
@@ -189,7 +189,7 @@ global $output_formatter;
 								<option value="DNSKEY" data-content-pattern="[0-9]+\s+[0-9]+\s+[0-9]+\s+.+">DNSKEY</option>
 								<option value="DS" data-content-pattern="[0-9]+\s+[0-9]+\s+[0-9]+\s+[a-zA-Z0-9]+">DS</option>
 								<option value="NAPTR" data-content-pattern="[0-9]+\s+[0-9]+\s+&quot;[a-zA-Z0-9]+&quot;\s*&quot;[^&quot;]*&quot;\s+&quot;[^&quot;]*&quot;\s+\S+">NAPTR</option>
-								<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+								<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 								<option value="NS" data-content-pattern="\S*">NS</option>
 								<?php } ?>
 								<option value="LOC" data-content-pattern="[0-9]{1,2} ([0-9]{1,3} ([0-9]{1,2}(\.[0-9]{1,3})?)?)? [NS] [0-9]{1,2} ([0-9]{1,3} ([0-9]{1,2}(\.[0-9]{1,3})?)?)? [EW] -?[0-9]+(\.[0-9]{1,2})?m?( [0-9]+(\.[0-9]{1,2})?m?( [0-9]+(\.[0-9]{1,2})?m?( [0-9]+(\.[0-9]{1,2})?m?)))">LOC</option>
@@ -231,7 +231,7 @@ global $output_formatter;
 				<div class="form-group"><label for="comment">Update comment</label><input type="text" id="comment" name="comment" class="form-control"<?php if($force_change_comment) out(' required');?>>
 				</div>
 				<div id="errors"></div>
-				<?php if(($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_superadmin($zone)) && !$force_change_review) { ?>
+				<?php if(($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_super_administrator($zone)) && !$force_change_review) { ?>
 				<p><button type="submit" id="zonesubmit" name="update_rrs" value="save" class="btn btn-primary">Save changes</button></p>
 				<?php } else { ?>
 				<p><button type="submit" id="zonesubmit" name="update_rrs" value="request" class="btn btn-primary">Request changes</button></p>
@@ -269,7 +269,7 @@ global $output_formatter;
 			<div class="panel panel-default">
 				<div class="panel-heading">
 					<div class="pull-right">
-						<?php if($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_superadmin($zone)) { ?>
+						<?php if($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_super_administrator($zone)) { ?>
 						<?php if($invalid_count == 0) { ?>
 						<button type="submit" name="approve_update" value="<?php out($update->id)?>" class="btn btn-xs btn-success"><span class="glyphicon glyphicon-ok"></span> Approve</button>
 						<?php } else { ?>
@@ -377,7 +377,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="kind" class="col-sm-2 control-label">Replication type</label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 					<select id="kind" name="kind" class="form-control" required>
 						<?php foreach($replication_types as $type) { ?>
 						<option value="<?php out($type->name)?>"<?php if($zone->kind == $type->name) out(' selected')?>><?php out($type->name)?></option>
@@ -391,7 +391,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="classification" class="col-sm-2 control-label">Classification</label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 					<?php if($force_account_whitelist) { ?>
 					<select class="form-control" id="classification" name="classification">
 						<?php foreach($account_whitelist as $account) { ?>
@@ -415,7 +415,7 @@ global $output_formatter;
 				</div>
 			</div>
 			<h3>Start of authority (SOA)</h3>
-			<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+			<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 			<div class="form-group">
 				<label class="col-sm-2 control-label">SOA templates</label>
 				<div class="col-sm-10">
@@ -429,7 +429,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="primary_ns" class="col-sm-2 control-label">Primary nameserver</label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 					<input type="text" class="form-control" id="primary_ns" name="primary_ns" required pattern="\S+" value="<?php out($zone->soa->primary_ns)?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out($zone->soa->primary_ns)?></p>
@@ -439,7 +439,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="contact" class="col-sm-2 control-label">Contact</label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 					<input type="text" class="form-control" id="contact" name="contact" required pattern="\S+" value="<?php out($zone->soa->contact)?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out($zone->soa->contact)?></p>
@@ -455,7 +455,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="refresh" class="col-sm-2 control-label"><abbr title="Indicates the time when the slave will try to refresh the zone from the master">Refresh</abbr></label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 					<input type="text" class="form-control" id="refresh" name="refresh" required pattern="([0-9]+[smhdwSMHDW]?)+" maxlength="40" value="<?php out(DNSTime::abbreviate($zone->soa->refresh))?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out(DNSTime::abbreviate($zone->soa->refresh))?></p>
@@ -465,7 +465,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="retry" class="col-sm-2 control-label"><abbr title="Defines the time between retries if the slave (secondary) fails to contact the master when refresh (above) has expired. Typical values would be 180 (3 minutes) to 900 (15 minutes) or higher.">Retry</abbr></label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 					<input type="text" class="form-control" id="retry" name="retry" required pattern="([0-9]+[smhdwSMHDW]?)+" maxlength="40" value="<?php out(DNSTime::abbreviate($zone->soa->retry))?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out(DNSTime::abbreviate($zone->soa->retry))?></p>
@@ -475,7 +475,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="expire" class="col-sm-2 control-label"><abbr title="Indicates when the zone data is no longer authoritative. Used by Slave (Secondary) servers only.">Expire</abbr></label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 					<input type="text" class="form-control" id="expire" name="expire" required pattern="([0-9]+[smhdwSMHDW]?)+" maxlength="40" value="<?php out(DNSTime::abbreviate($zone->soa->expiry))?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out(DNSTime::abbreviate($zone->soa->expiry))?></p>
@@ -485,7 +485,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="default_ttl" class="col-sm-2 control-label"><abbr title="The time a NAME ERROR = NXDOMAIN result may be cached by any resolver.">Default TTL</abbr></label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 					<input type="text" class="form-control" id="default_ttl" name="default_ttl" required pattern="([0-9]+[smhdwSMHDW]?)+" maxlength="40" value="<?php out(DNSTime::abbreviate($zone->soa->default_ttl))?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out(DNSTime::abbreviate($zone->soa->default_ttl))?></p>
@@ -495,7 +495,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="soa_ttl" class="col-sm-2 control-label"><abbr title="The time this SOA record may be cached by any resolver.">SOA TTL</abbr></label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 					<input type="text" class="form-control" id="soa_ttl" name="soa_ttl" required pattern="([0-9]+[smhdwSMHDW]?)+" maxlength="40" value="<?php out(DNSTime::abbreviate($zone->soa->ttl))?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out(DNSTime::abbreviate($zone->soa->ttl))?></p>
@@ -503,7 +503,7 @@ global $output_formatter;
 				</div>
 			</div>
 			<hr>
-			<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+			<?php if($active_user->admin || $active_user->is_zone_super_administrator($zone)) { ?>
 			<div class="form-group">
 				<label for="soa_change_comment" class="col-sm-2 control-label">Change comment</label>
 				<div class="col-sm-10">
@@ -795,8 +795,8 @@ global $output_formatter;
 				<div class="col-sm-6">
 					<div class="radio">
 						<label>
-							<input type="radio" name="level" value="superadministrator">
-							Zone Superadmin&mdash;can directly edit any records in the zone including SOA and NS records
+							<input type="radio" name="level" value="zone-super-administrator">
+							Zone Super Administrator&mdash;can directly edit any records in the zone including SOA and NS records
 						</label>
 					</div>
 					<div class="radio">

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -66,7 +66,7 @@ global $output_formatter;
 <div class="tab-content">
 	<div role="tabpanel" class="tab-pane active" id="records">
 		<h2 class="sr-only">Resource records</h2>
-		<form method="post" action="<?php outurl('/zones/'.urlencode(DNSZoneName::unqualify($zone->name)))?>" class="zoneedit" data-zone="<?php out($zone->name)?>" data-local-zone="<?php out($local_zone ? 1 : 0)?>" data-local-ipv4-ranges="<?php out($local_ipv4_ranges)?>" data-local-ipv6-ranges="<?php out($local_ipv6_ranges)?>">
+		<form method="post" action="<?php outurl('/zones/'.urlencode(DNSZoneName::unqualify($zone->name)))?>" class="zoneedit" data-zone="<?php out($zone->name)?>" data-local-zone="<?php out($local_zone ? 1 : 0)?>" data-local-ipv4-ranges="<?php out($local_ipv4_ranges)?>" data-local-ipv6-ranges="<?php out($local_ipv6_ranges)?>" data-user-admin="<?php out($active_user->admin ? 1 : 0)?>" data-user-superadmin="<?php out($active_user->is_zone_superadmin($zone) ? 1 : 0)?>">
 			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 			<nav></nav>
 			<table class="table table-bordered table-condensed table-hover stickyHeader rrsets">
@@ -86,8 +86,6 @@ global $output_formatter;
 					$rrsetnum = 0;
 					foreach($rrsets as $rrset) {
 						if($rrset->type == 'SOA') continue;
-						if($rrset->type == 'NS' && !($active_user->admin || $active_user->is_zone_superadmin($zone))) continue;
-						if($rrset->type == 'CAA' && !($active_user->admin || $active_user->is_zone_superadmin($zone))) continue;
 						$rrsetnum++;
 						$rrs = $rrset->list_resource_records();
 						$name = DNSName::abbreviate($rrset->name, $zone->name);
@@ -101,7 +99,7 @@ global $output_formatter;
 						if($alldisabled) $rowclasses[] = 'rrset-disable';
 						if($rrsetnum > $maxperpage) $rowclasses[] = 'hidden';
 						?>
-					<tr data-name="<?php out(punycode_to_utf8($name))?>" data-type="<?php out($rrset->type)?>" data-rrsetnum="<?php out($rrsetnum)?>" class="<?php out(implode(' ', $rowclasses))?>">
+					<tr data-name="<?php out(punycode_to_utf8($name))?>" data-type="<?php out($rrset->type)?>" data-rrsetnum="<?php out($rrsetnum)?>" class="<?php out(implode(' ', $rowclasses))?><?php if(($rrset->type == 'NS' || $rrset->type == 'CAA') && !($active_user->admin || $active_user->is_zone_superadmin($zone))) echo ' read-only'; ?>">
 						<td class="name" rowspan="<?php out(count($rrs))?>"><?php out(punycode_to_utf8($name))?></td>
 						<td class="type" rowspan="<?php out(count($rrs))?>"><?php out($rrset->type)?></td>
 						<td class="ttl" rowspan="<?php out(count($rrs))?>"><?php out(DNSTime::abbreviate($rrset->ttl))?></td>
@@ -140,7 +138,15 @@ global $output_formatter;
 						?></td>
 						<td class="enabled"><?php out($rr->disabled ? 'No' : 'Yes')?></td>
 						<td class="actions">
-							<button type="button" class="btn btn-default btn-xs delete-rr"><span class="glyphicon glyphicon-trash"></span> Delete</button>
+							<?php if($rrset->type == 'NS' || $rrset->type == 'CAA') { ?>
+								<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
+									<button type="button" class="btn btn-default btn-xs delete-rr"><span class="glyphicon glyphicon-trash"></span> Delete</button>
+								<?php } else { ?>
+									<span class="text-muted">Read-only</span>
+								<?php } ?>
+							<?php } else { ?>
+								<button type="button" class="btn btn-default btn-xs delete-rr"><span class="glyphicon glyphicon-trash"></span> Delete</button>
+							<?php } ?>
 						</td>
 						<?php if($count == 1) { ?>
 						<td class="comment" rowspan="<?php out(count($rrs))?>"><?php out($rrset->merge_comment_text())?></td>

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -86,7 +86,7 @@ global $output_formatter;
 					$rrsetnum = 0;
 					foreach($rrsets as $rrset) {
 						if($rrset->type == 'SOA') continue;
-						if($rrset->type == 'NS' && !$active_user->admin) continue;
+						if($rrset->type == 'NS' && !($active_user->admin || $active_user->is_zone_superadmin($zone))) continue;
 						$rrsetnum++;
 						$rrs = $rrset->list_resource_records();
 						$name = DNSName::abbreviate($rrset->name, $zone->name);
@@ -164,7 +164,7 @@ global $output_formatter;
 								<?php if($reverse) { ?>
 								<option value="CNAME" data-content-pattern="\S+">CNAME</option>
 								<option value="DS" data-content-pattern="[0-9]+\s+[0-9]+\s+[0-9]+\s+[a-zA-Z0-9]+">DS</option>
-								<?php if($active_user->admin) { ?>
+								<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
 								<option value="NS" data-content-pattern="\S*">NS</option>
 								<?php } ?>
 								<option value="PTR" data-content-pattern="\S+">PTR</option>
@@ -180,7 +180,7 @@ global $output_formatter;
 								<option value="DNSKEY" data-content-pattern="[0-9]+\s+[0-9]+\s+[0-9]+\s+.+">DNSKEY</option>
 								<option value="DS" data-content-pattern="[0-9]+\s+[0-9]+\s+[0-9]+\s+[a-zA-Z0-9]+">DS</option>
 								<option value="NAPTR" data-content-pattern="[0-9]+\s+[0-9]+\s+&quot;[a-zA-Z0-9]+&quot;\s*&quot;[^&quot;]*&quot;\s+&quot;[^&quot;]*&quot;\s+\S+">NAPTR</option>
-								<?php if($active_user->admin) { ?>
+								<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
 								<option value="NS" data-content-pattern="\S*">NS</option>
 								<?php } ?>
 								<option value="LOC" data-content-pattern="[0-9]{1,2} ([0-9]{1,3} ([0-9]{1,2}(\.[0-9]{1,3})?)?)? [NS] [0-9]{1,2} ([0-9]{1,3} ([0-9]{1,2}(\.[0-9]{1,3})?)?)? [EW] -?[0-9]+(\.[0-9]{1,2})?m?( [0-9]+(\.[0-9]{1,2})?m?( [0-9]+(\.[0-9]{1,2})?m?( [0-9]+(\.[0-9]{1,2})?m?)))">LOC</option>
@@ -219,9 +219,10 @@ global $output_formatter;
 				<ul id="collisions_list">
 				</ul>
 				<input type="hidden" name="serial" value="<?php out($zone->soa->serial)?>">
-				<div class="form-group"><label for="comment">Update comment</label><input type="text" id="comment" name="comment" class="form-control"<?php if($force_change_comment) out(' required');?>></div>
+				<div class="form-group"><label for="comment">Update comment</label><input type="text" id="comment" name="comment" class="form-control"<?php if($force_change_comment) out(' required');?>>
+				</div>
 				<div id="errors"></div>
-				<?php if(($active_user->admin || $active_user->access_to($zone) == 'administrator') && !$force_change_review) { ?>
+				<?php if(($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_superadmin($zone)) && !$force_change_review) { ?>
 				<p><button type="submit" id="zonesubmit" name="update_rrs" value="save" class="btn btn-primary">Save changes</button></p>
 				<?php } else { ?>
 				<p><button type="submit" id="zonesubmit" name="update_rrs" value="request" class="btn btn-primary">Request changes</button></p>
@@ -259,7 +260,7 @@ global $output_formatter;
 			<div class="panel panel-default">
 				<div class="panel-heading">
 					<div class="pull-right">
-						<?php if($active_user->admin || $active_user->access_to($zone) == 'administrator') { ?>
+						<?php if($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_superadmin($zone)) { ?>
 						<?php if($invalid_count == 0) { ?>
 						<button type="submit" name="approve_update" value="<?php out($update->id)?>" class="btn btn-xs btn-success"><span class="glyphicon glyphicon-ok"></span> Approve</button>
 						<?php } else { ?>
@@ -367,7 +368,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="kind" class="col-sm-2 control-label">Replication type</label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
 					<select id="kind" name="kind" class="form-control" required>
 						<?php foreach($replication_types as $type) { ?>
 						<option value="<?php out($type->name)?>"<?php if($zone->kind == $type->name) out(' selected')?>><?php out($type->name)?></option>
@@ -381,7 +382,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="classification" class="col-sm-2 control-label">Classification</label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
 					<?php if($force_account_whitelist) { ?>
 					<select class="form-control" id="classification" name="classification">
 						<?php foreach($account_whitelist as $account) { ?>
@@ -405,7 +406,7 @@ global $output_formatter;
 				</div>
 			</div>
 			<h3>Start of authority (SOA)</h3>
-			<?php if($active_user->admin) { ?>
+			<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
 			<div class="form-group">
 				<label class="col-sm-2 control-label">SOA templates</label>
 				<div class="col-sm-10">
@@ -419,7 +420,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="primary_ns" class="col-sm-2 control-label">Primary nameserver</label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
 					<input type="text" class="form-control" id="primary_ns" name="primary_ns" required pattern="\S+" value="<?php out($zone->soa->primary_ns)?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out($zone->soa->primary_ns)?></p>
@@ -429,7 +430,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="contact" class="col-sm-2 control-label">Contact</label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
 					<input type="text" class="form-control" id="contact" name="contact" required pattern="\S+" value="<?php out($zone->soa->contact)?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out($zone->soa->contact)?></p>
@@ -445,7 +446,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="refresh" class="col-sm-2 control-label"><abbr title="Indicates the time when the slave will try to refresh the zone from the master">Refresh</abbr></label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
 					<input type="text" class="form-control" id="refresh" name="refresh" required pattern="([0-9]+[smhdwSMHDW]?)+" maxlength="40" value="<?php out(DNSTime::abbreviate($zone->soa->refresh))?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out(DNSTime::abbreviate($zone->soa->refresh))?></p>
@@ -455,7 +456,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="retry" class="col-sm-2 control-label"><abbr title="Defines the time between retries if the slave (secondary) fails to contact the master when refresh (above) has expired. Typical values would be 180 (3 minutes) to 900 (15 minutes) or higher.">Retry</abbr></label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
 					<input type="text" class="form-control" id="retry" name="retry" required pattern="([0-9]+[smhdwSMHDW]?)+" maxlength="40" value="<?php out(DNSTime::abbreviate($zone->soa->retry))?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out(DNSTime::abbreviate($zone->soa->retry))?></p>
@@ -465,7 +466,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="expire" class="col-sm-2 control-label"><abbr title="Indicates when the zone data is no longer authoritative. Used by Slave (Secondary) servers only.">Expire</abbr></label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
 					<input type="text" class="form-control" id="expire" name="expire" required pattern="([0-9]+[smhdwSMHDW]?)+" maxlength="40" value="<?php out(DNSTime::abbreviate($zone->soa->expiry))?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out(DNSTime::abbreviate($zone->soa->expiry))?></p>
@@ -475,7 +476,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="default_ttl" class="col-sm-2 control-label"><abbr title="The time a NAME ERROR = NXDOMAIN result may be cached by any resolver.">Default TTL</abbr></label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
 					<input type="text" class="form-control" id="default_ttl" name="default_ttl" required pattern="([0-9]+[smhdwSMHDW]?)+" maxlength="40" value="<?php out(DNSTime::abbreviate($zone->soa->default_ttl))?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out(DNSTime::abbreviate($zone->soa->default_ttl))?></p>
@@ -485,7 +486,7 @@ global $output_formatter;
 			<div class="form-group">
 				<label for="soa_ttl" class="col-sm-2 control-label"><abbr title="The time this SOA record may be cached by any resolver.">SOA TTL</abbr></label>
 				<div class="col-sm-10">
-					<?php if($active_user->admin) { ?>
+					<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
 					<input type="text" class="form-control" id="soa_ttl" name="soa_ttl" required pattern="([0-9]+[smhdwSMHDW]?)+" maxlength="40" value="<?php out(DNSTime::abbreviate($zone->soa->ttl))?>">
 					<?php } else { ?>
 					<p class="form-control-static"><?php out(DNSTime::abbreviate($zone->soa->ttl))?></p>
@@ -493,7 +494,7 @@ global $output_formatter;
 				</div>
 			</div>
 			<hr>
-			<?php if($active_user->admin) { ?>
+			<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
 			<div class="form-group">
 				<label for="soa_change_comment" class="col-sm-2 control-label">Change comment</label>
 				<div class="col-sm-10">
@@ -783,6 +784,12 @@ global $output_formatter;
 			<div class="form-group">
 				<label class="col-sm-2 control-label">Access level</label>
 				<div class="col-sm-6">
+					<div class="radio">
+						<label>
+							<input type="radio" name="level" value="superadministrator">
+							Zone Superadmin&mdash;can directly edit any records in the zone including SOA and NS records
+						</label>
+					</div>
 					<div class="radio">
 						<label>
 							<input type="radio" name="level" value="administrator" checked>

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -66,7 +66,7 @@ global $output_formatter;
 <div class="tab-content">
 	<div role="tabpanel" class="tab-pane active" id="records">
 		<h2 class="sr-only">Resource records</h2>
-		<form method="post" action="<?php outurl('/zones/'.urlencode(DNSZoneName::unqualify($zone->name)))?>" class="zoneedit" data-zone="<?php out($zone->name)?>" data-local-zone="<?php out($local_zone ? 1 : 0)?>" data-local-ipv4-ranges="<?php out($local_ipv4_ranges)?>" data-local-ipv6-ranges="<?php out($local_ipv6_ranges)?>" data-user-admin="<?php out($active_user->admin ? 1 : 0)?>" data-user-superadmin="<?php out($active_user->is_zone_superadmin($zone) ? 1 : 0)?>">
+		<form method="post" action="<?php outurl('/zones/'.urlencode(DNSZoneName::unqualify($zone->name)))?>" class="zoneedit" data-zone="<?php out($zone->name)?>" data-local-zone="<?php out($local_zone ? 1 : 0)?>" data-local-ipv4-ranges="<?php out($local_ipv4_ranges)?>" data-local-ipv6-ranges="<?php out($local_ipv6_ranges)?>" data-user-admin="<?php out($active_user->admin ? 1 : 0)?>" data-user-super-zone-admin="<?php out($active_user->is_zone_superadmin($zone) ? 1 : 0)?>">
 			<?php out($this->get('active_user')->get_csrf_field(), ESC_NONE) ?>
 			<nav></nav>
 			<table class="table table-bordered table-condensed table-hover stickyHeader rrsets">

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -87,6 +87,7 @@ global $output_formatter;
 					foreach($rrsets as $rrset) {
 						if($rrset->type == 'SOA') continue;
 						if($rrset->type == 'NS' && !($active_user->admin || $active_user->is_zone_superadmin($zone))) continue;
+						if($rrset->type == 'CAA' && !($active_user->admin || $active_user->is_zone_superadmin($zone))) continue;
 						$rrsetnum++;
 						$rrs = $rrset->list_resource_records();
 						$name = DNSName::abbreviate($rrset->name, $zone->name);
@@ -172,7 +173,9 @@ global $output_formatter;
 								<option value="A" data-content-pattern="((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])">A</option>
 								<option value="AAAA" data-content-pattern="(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))">AAAA</option>
 								<option value="ALIAS" data-content-pattern="\S+">ALIAS</option>
+								<?php if($active_user->admin || $active_user->is_zone_superadmin($zone)) { ?>
 								<option value="CAA" data-content-pattern="[0-9]+\s+\S+\s+\S+">CAA</option>
+								<?php } ?>
 								<option value="CNAME" data-content-pattern="\S+">CNAME</option>
 								<!-- DHCID regex contributed under CC BY-SA 4.0 by njzk2 (https://stackoverflow.com/users/671543/njzk2) on Stack Overflow: https://stackoverflow.com/a/5885097 -->
 								<option value="DHCID" data-content-pattern="^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$">DHCID</option>
@@ -818,3 +821,4 @@ global $output_formatter;
 		<?php } ?>
 	</div>
 </div>
+

--- a/templates/zone.php
+++ b/templates/zone.php
@@ -771,7 +771,21 @@ global $output_formatter;
 					<?php foreach($access as $rule) { ?>
 					<tr>
 						<td><?php out($rule->user->name)?></td>
-						<td><?php out(ucfirst($rule->level))?></td>
+						<td><?php 
+							switch($rule->level) {
+								case 'zone-super-administrator':
+									echo 'Zone Super Administrator';
+									break;
+								case 'administrator':
+									echo 'Administrator';
+									break;
+								case 'operator':
+									echo 'Operator';
+									break;
+								default:
+									echo ucfirst($rule->level);
+							}
+						?></td>
 						<?php if($active_user->admin) { ?>
 						<td><button type="submit" name="delete_access" value="<?php out($rule->user->uid)?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-trash"></span> Remove</button></td>
 						<?php } ?>

--- a/views/zone.php
+++ b/views/zone.php
@@ -110,7 +110,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 		foreach($_POST['updates'] as $update) {
 			$json->actions[] = json_decode($update);
 		}
-		if(($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_superadmin($zone)) && !$force_change_review) {
+		if(($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_super_administrator($zone)) && !$force_change_review) {
 			try {
 				$zone->process_bulk_json_rrset_update(json_encode($json));
 				redirect();
@@ -128,10 +128,10 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 		} else {
 			$zone->add_pending_update(json_encode($json));
 			$mail = new Email;
-			// Mail SOA contact and administrators/superadministrators about pending update
+			// Mail SOA contact and administrators/super zone administrators about pending update
 			$mail->add_recipient(preg_replace('/^([^\.]+)\./', '$1@', trim($zone->soa->contact, '.')));
 			foreach($zone->list_access() as $access) {
-				if($access->level == 'administrator' || $access->level == 'superadministrator') {
+				if($access->level == 'administrator' || $access->level == 'zone-super-administrator') {
 					$mail->add_recipient($access->user->email, $access->user->name);
 				}
 			}
@@ -158,7 +158,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 			$zone->delete_pending_update($update);
 		}
 		redirect();
-	} elseif(isset($_POST['approve_update']) && ($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_superadmin($zone))) {
+	} elseif(isset($_POST['approve_update']) && ($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_super_administrator($zone))) {
 		try {
 			$update = $zone->get_pending_update_by_id($_POST['approve_update']);
 		} catch(PendingUpdateNotFound $e) {
@@ -189,7 +189,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 			$content = new PageSection('zone_update_failed');
 			$content->set('message', $e->getMessage());
 		}
-	} elseif(isset($_POST['reject_update']) && ($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_superadmin($zone))) {
+	} elseif(isset($_POST['reject_update']) && ($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_super_administrator($zone))) {
 		try {
 			$update = $zone->get_pending_update_by_id($_POST['reject_update']);
 		} catch(PendingUpdateNotFound $e) {
@@ -213,7 +213,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 		$alert->content = "Change request rejected.";
 		$active_user->add_alert($alert);
 		redirect();
-	} elseif(isset($_POST['update_zone']) && ($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_superadmin($zone))) {
+	} elseif(isset($_POST['update_zone']) && ($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_super_administrator($zone))) {
 		$zone->kind = $_POST['kind'];
 		$zone->account = $_POST['classification'];
 		$zone->update();

--- a/views/zone.php
+++ b/views/zone.php
@@ -126,7 +126,34 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 				$content->set('message', $e->getMessage());
 			}
 		} else {
-			$zone->add_pending_update(json_encode($json));
+			// Security check: Prevent creation of pending updates for restricted record types
+			// Only global admins and zone super administrators can request changes to SOA, NS, and CAA records
+			$restricted_changes = false;
+			foreach($json->actions as $action) {
+				if(($action->type == 'SOA' || $action->type == 'NS' || $action->type == 'CAA') ||
+				   (isset($action->oldtype) && ($action->oldtype == 'SOA' || $action->oldtype == 'NS' || $action->oldtype == 'CAA'))) {
+					$restricted_changes = true;
+					break;
+				}
+			}
+			
+			if($restricted_changes && !($active_user->admin || $active_user->is_zone_super_administrator($zone))) {
+				$alert = new UserAlert;
+				$alert->content = "You are not authorized to request changes to SOA, NS, or CAA records.";
+				$alert->class = "error";
+				$active_user->add_alert($alert);
+				redirect();
+			}
+			
+			try {
+				$zone->add_pending_update(json_encode($json));
+			} catch(RuntimeException $e) {
+				$alert = new UserAlert;
+				$alert->content = $e->getMessage();
+				$alert->class = "error";
+				$active_user->add_alert($alert);
+				redirect();
+			}
 			$mail = new Email;
 			// Mail SOA contact and administrators/super zone administrators about pending update
 			$mail->add_recipient(preg_replace('/^([^\.]+)\./', '$1@', trim($zone->soa->contact, '.')));

--- a/views/zone.php
+++ b/views/zone.php
@@ -110,7 +110,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 		foreach($_POST['updates'] as $update) {
 			$json->actions[] = json_decode($update);
 		}
-		if(($active_user->admin || $active_user->access_to($zone) == 'administrator') && !$force_change_review) {
+		if(($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_superadmin($zone)) && !$force_change_review) {
 			try {
 				$zone->process_bulk_json_rrset_update(json_encode($json));
 				redirect();
@@ -128,10 +128,10 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 		} else {
 			$zone->add_pending_update(json_encode($json));
 			$mail = new Email;
-			// Mail SOA contact and administrators about pending update
+			// Mail SOA contact and administrators/superadministrators about pending update
 			$mail->add_recipient(preg_replace('/^([^\.]+)\./', '$1@', trim($zone->soa->contact, '.')));
 			foreach($zone->list_access() as $access) {
-				if($access->level == 'administrator') {
+				if($access->level == 'administrator' || $access->level == 'superadministrator') {
 					$mail->add_recipient($access->user->email, $access->user->name);
 				}
 			}
@@ -158,7 +158,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 			$zone->delete_pending_update($update);
 		}
 		redirect();
-	} elseif(isset($_POST['approve_update']) && ($active_user->admin || $active_user->access_to($zone) == 'administrator')) {
+	} elseif(isset($_POST['approve_update']) && ($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_superadmin($zone))) {
 		try {
 			$update = $zone->get_pending_update_by_id($_POST['approve_update']);
 		} catch(PendingUpdateNotFound $e) {
@@ -189,7 +189,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 			$content = new PageSection('zone_update_failed');
 			$content->set('message', $e->getMessage());
 		}
-	} elseif(isset($_POST['reject_update']) && ($active_user->admin || $active_user->access_to($zone) == 'administrator')) {
+	} elseif(isset($_POST['reject_update']) && ($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_superadmin($zone))) {
 		try {
 			$update = $zone->get_pending_update_by_id($_POST['reject_update']);
 		} catch(PendingUpdateNotFound $e) {
@@ -213,7 +213,7 @@ if($_SERVER['REQUEST_METHOD'] == 'POST') {
 		$alert->content = "Change request rejected.";
 		$active_user->add_alert($alert);
 		redirect();
-	} elseif(isset($_POST['update_zone']) && ($active_user->admin || $active_user->access_to($zone) == 'administrator')) {
+	} elseif(isset($_POST['update_zone']) && ($active_user->admin || $active_user->access_to($zone) == 'administrator' || $active_user->is_zone_superadmin($zone))) {
 		$zone->kind = $_POST['kind'];
 		$zone->account = $_POST['classification'];
 		$zone->update();


### PR DESCRIPTION
# Summary of changes

## Key changes:

- Added new `zone-super-administrator` role to enum `access_level` (migration 007.php)
- Added `is_zone_super_administrator()` method to User class
- Added user info display in top navigation bar (Name Surname (username))

## What zone super administrators can do:

- Edit NS and CAA records (previously only global admins could do this)
- Edit zone SOA settings (previously only global admins could do this)
- Approve/reject change requests
- Add new NS and CAA records

## Security improvements:

- Restricted NS and CAA record editing for standard operators and zone administrators
- Added JavaScript validation to prevent unauthorized editing attempts
- Added visual styling for read-only records (opacity, cursor, hover effects)
- Updated email notifications to include super administrators

## UI/UX improvements:

- Added user info display in top navigation bar showing "Name Surname (username)" with user icon
